### PR TITLE
Restore message type `ResponseStatus`

### DIFF
--- a/autoware_external_api_msgs/CMakeLists.txt
+++ b/autoware_external_api_msgs/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
 rosidl_generate_interfaces(${PROJECT_NAME}
+  msg/ResponseStatus.msg
   srv/GetVersion.srv
   DEPENDENCIES
     tier4_external_api_msgs

--- a/autoware_external_api_msgs/msg/ResponseStatus.msg
+++ b/autoware_external_api_msgs/msg/ResponseStatus.msg
@@ -1,0 +1,9 @@
+# constants
+uint32 SUCCESS=1
+uint32 IGNORED=2
+uint32 WARN=3
+uint32 ERROR=4
+
+# fields
+uint32 code
+string message

--- a/autoware_external_api_msgs/msg/ResponseStatus.msg
+++ b/autoware_external_api_msgs/msg/ResponseStatus.msg
@@ -1,3 +1,7 @@
+# This message type is deprecated. However, this message type is maintained
+# because autoware_hmi_msgs (https://github.com/tier4/AutowareArchitectureProposal_msgs/tree/main/autoware_hmi_msgs)
+# depends on this message type.
+
 # constants
 uint32 SUCCESS=1
 uint32 IGNORED=2


### PR DESCRIPTION
## PR Type

- New Feature

## Related Links

None.

## Description

Restored the message type `ResponseStatus`, which was in` AutowareArchitectureProposal_api_msgs` but was obsolete when ported to this repository.

This change is for `scenario_simulator_v2:tier4/universe`.

`scenario_simulator_v2` relies on `AAP_msgs:main` (or `tier4/autoware_iv_msgs`) for backward compatibility with AAP. The package `autoware_hmi_msgs` in that` AAP_msgs:main` requires the message type `ResponseStatus`.

## Review Procedure

Check if the build test passes.

## Remarks

None.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Code follows [coding guidelines][coding-guidelines]
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s).
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
