### PR TITLE
Fix awapi autoware state

### DIFF
--- a/awapi_awiv_adapter/include/awapi_awiv_adapter/awapi_autoware_state_publisher.hpp
+++ b/awapi_awiv_adapter/include/awapi_awiv_adapter/awapi_autoware_state_publisher.hpp
@@ -43,10 +43,10 @@ private:
 
   /* parameter for judging goal now */
   bool arrived_goal_;
-  autoware_auto_system_msgs::msg::AutowareState::_state_type prev_state_;
+  tier4_system_msgs::msg::AutowareState::_state_type prev_state_;
 
   void getAutowareStateInfo(
-    const autoware_auto_system_msgs::msg::AutowareState::ConstSharedPtr & autoware_state_ptr,
+    const tier4_system_msgs::msg::AutowareState::ConstSharedPtr & autoware_state_ptr,
     tier4_api_msgs::msg::AwapiAutowareStatus * status);
   void getControlModeInfo(
     const autoware_auto_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr & control_mode_ptr,
@@ -72,7 +72,7 @@ private:
     const pacmod3_msgs::msg::GlobalRpt::ConstSharedPtr & global_rpt_ptr,
     tier4_api_msgs::msg::AwapiAutowareStatus * status);
 
-  bool isGoal(const autoware_auto_system_msgs::msg::AutowareState::ConstSharedPtr & autoware_state);
+  bool isGoal(const tier4_system_msgs::msg::AutowareState::ConstSharedPtr & autoware_state);
 };
 
 }  // namespace autoware_api

--- a/awapi_awiv_adapter/include/awapi_awiv_adapter/awapi_autoware_util.hpp
+++ b/awapi_awiv_adapter/include/awapi_awiv_adapter/awapi_autoware_util.hpp
@@ -20,7 +20,6 @@
 #include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
 #include <autoware_auto_planning_msgs/msg/path.hpp>
 #include <autoware_auto_planning_msgs/msg/trajectory.hpp>
-#include <autoware_auto_system_msgs/msg/autoware_state.hpp>
 #include <autoware_auto_system_msgs/msg/emergency_state.hpp>
 #include <autoware_auto_system_msgs/msg/hazard_status_stamped.hpp>
 #include <autoware_auto_vehicle_msgs/msg/control_mode_report.hpp>
@@ -41,6 +40,7 @@
 #include <tier4_planning_msgs/msg/lane_change_status.hpp>
 #include <tier4_planning_msgs/msg/stop_reason_array.hpp>
 #include <tier4_planning_msgs/msg/velocity_limit.hpp>
+#include <tier4_system_msgs/msg/autoware_state.hpp>
 #include <tier4_v2x_msgs/msg/infrastructure_command_array.hpp>
 #include <tier4_v2x_msgs/msg/virtual_traffic_light_state_array.hpp>
 #include <tier4_vehicle_msgs/msg/battery_status.hpp>
@@ -65,7 +65,7 @@ struct AutowareInfo
   autoware_auto_vehicle_msgs::msg::GearReport::ConstSharedPtr gear_ptr;
   tier4_vehicle_msgs::msg::BatteryStatus::ConstSharedPtr battery_ptr;
   sensor_msgs::msg::NavSatFix::ConstSharedPtr nav_sat_ptr;
-  autoware_auto_system_msgs::msg::AutowareState::ConstSharedPtr autoware_state_ptr;
+  tier4_system_msgs::msg::AutowareState::ConstSharedPtr autoware_state_ptr;
   autoware_auto_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr control_mode_ptr;
   tier4_control_msgs::msg::GateMode::ConstSharedPtr gate_mode_ptr;
   autoware_auto_system_msgs::msg::EmergencyState::ConstSharedPtr emergency_state_ptr;

--- a/awapi_awiv_adapter/include/awapi_awiv_adapter/awapi_awiv_adapter_core.hpp
+++ b/awapi_awiv_adapter/include/awapi_awiv_adapter/awapi_awiv_adapter_core.hpp
@@ -30,7 +30,6 @@
 #include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
 #include <autoware_auto_planning_msgs/msg/path.hpp>
 #include <autoware_auto_planning_msgs/msg/trajectory.hpp>
-#include <autoware_auto_system_msgs/msg/autoware_state.hpp>
 #include <autoware_auto_system_msgs/msg/emergency_state.hpp>
 #include <autoware_auto_vehicle_msgs/msg/control_mode_report.hpp>
 #include <autoware_auto_vehicle_msgs/msg/gear_report.hpp>
@@ -43,6 +42,7 @@
 #include <sensor_msgs/msg/nav_sat_fix.hpp>
 #include <tier4_control_msgs/msg/gate_mode.hpp>
 #include <tier4_planning_msgs/msg/stop_reason_array.hpp>
+#include <tier4_system_msgs/msg/autoware_state.hpp>
 #include <tier4_v2x_msgs/msg/infrastructure_command_array.hpp>
 #include <tier4_v2x_msgs/msg/virtual_traffic_light_state_array.hpp>
 
@@ -71,7 +71,7 @@ private:
   rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::GearReport>::SharedPtr sub_gear_;
   rclcpp::Subscription<tier4_vehicle_msgs::msg::BatteryStatus>::SharedPtr sub_battery_;
   rclcpp::Subscription<sensor_msgs::msg::NavSatFix>::SharedPtr sub_nav_sat_;
-  rclcpp::Subscription<autoware_auto_system_msgs::msg::AutowareState>::SharedPtr
+  rclcpp::Subscription<tier4_system_msgs::msg::AutowareState>::SharedPtr
     sub_autoware_state_;
   rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::ControlModeReport>::SharedPtr
     sub_control_mode_;
@@ -129,7 +129,7 @@ private:
   void callbackBattery(const tier4_vehicle_msgs::msg::BatteryStatus::ConstSharedPtr msg_ptr);
   void callbackNavSat(const sensor_msgs::msg::NavSatFix::ConstSharedPtr msg_ptr);
   void callbackAutowareState(
-    const autoware_auto_system_msgs::msg::AutowareState::ConstSharedPtr msg_ptr);
+    const tier4_system_msgs::msg::AutowareState::ConstSharedPtr msg_ptr);
   void callbackControlMode(
     const autoware_auto_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr msg_ptr);
   void callbackGateMode(const tier4_control_msgs::msg::GateMode::ConstSharedPtr msg_ptr);

--- a/awapi_awiv_adapter/launch/awapi_awiv_adapter.launch.xml
+++ b/awapi_awiv_adapter/launch/awapi_awiv_adapter.launch.xml
@@ -13,7 +13,7 @@
   <arg name="input_gear" default="/vehicle/status/gear_status" />
   <arg name="input_battery" default="/vehicle/status/battery_charge" />
   <arg name="input_nav_sat" default="/sensing/gnss/ublox/nav_sat_fix" />
-  <arg name="input_autoware_state" default="/autoware/state" />
+  <arg name="input_autoware_state" default="/api/iv_msgs/autoware/state" />
   <arg name="input_control_mode" default="/vehicle/status/control_mode" />
   <arg name="input_gate_mode" default="/control/current_gate_mode" />
   <arg name="input_emergency_state" default="/system/emergency/emergency_state" />

--- a/awapi_awiv_adapter/package.xml
+++ b/awapi_awiv_adapter/package.xml
@@ -27,6 +27,7 @@
   <depend>tier4_control_msgs</depend>
   <depend>tier4_external_api_msgs</depend>
   <depend>tier4_planning_msgs</depend>
+  <depend>tier4_system_msgs</depend>
   <depend>tier4_v2x_msgs</depend>
   <depend>tier4_vehicle_msgs</depend>
 

--- a/awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp
+++ b/awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp
@@ -58,7 +58,7 @@ void AutowareIvAutowareStatePublisher::statePublisher(const AutowareInfo & aw_in
 }
 
 void AutowareIvAutowareStatePublisher::getAutowareStateInfo(
-  const autoware_auto_system_msgs::msg::AutowareState::ConstSharedPtr & autoware_state_ptr,
+  const tier4_system_msgs::msg::AutowareState::ConstSharedPtr & autoware_state_ptr,
   tier4_api_msgs::msg::AwapiAutowareStatus * status)
 {
   if (!autoware_state_ptr) {
@@ -68,7 +68,7 @@ void AutowareIvAutowareStatePublisher::getAutowareStateInfo(
 
   // get autoware_state
   using tier4_auto_msgs_converter::convert;
-  status->autoware_state = convert(*autoware_state_ptr).state;
+  status->autoware_state = autoware_state_ptr->state;
   status->arrived_goal = isGoal(autoware_state_ptr);
 }
 
@@ -199,7 +199,7 @@ void AutowareIvAutowareStatePublisher::getDiagInfo(
 void AutowareIvAutowareStatePublisher::getErrorDiagInfo(
   const AutowareInfo & aw_info, tier4_api_msgs::msg::AwapiAutowareStatus * status)
 {
-  using autoware_auto_system_msgs::msg::AutowareState;
+  using tier4_system_msgs::msg::AutowareState;
   using autoware_auto_vehicle_msgs::msg::ControlModeReport;
 
   if (!aw_info.autoware_state_ptr) {
@@ -274,22 +274,22 @@ void AutowareIvAutowareStatePublisher::getGlobalRptInfo(
 }
 
 bool AutowareIvAutowareStatePublisher::isGoal(
-  const autoware_auto_system_msgs::msg::AutowareState::ConstSharedPtr & autoware_state)
+  const tier4_system_msgs::msg::AutowareState::ConstSharedPtr & autoware_state)
 {
   // rename
   const auto & aw_state = autoware_state->state;
 
-  if (aw_state == autoware_auto_system_msgs::msg::AutowareState::ARRIVED_GOAL) {
+  if (aw_state == tier4_system_msgs::msg::AutowareState::ARRIVAL_GOAL) {
     arrived_goal_ = true;
   } else if (  // NOLINT
-    prev_state_ == autoware_auto_system_msgs::msg::AutowareState::DRIVING &&
-    aw_state == autoware_auto_system_msgs::msg::AutowareState::WAITING_FOR_ROUTE) {
+    prev_state_ == tier4_system_msgs::msg::AutowareState::DRIVING &&
+    aw_state == tier4_system_msgs::msg::AutowareState::WAITING_FOR_ROUTE) {
     arrived_goal_ = true;
   }
 
   if (
-    aw_state == autoware_auto_system_msgs::msg::AutowareState::WAITING_FOR_ENGAGE ||
-    aw_state == autoware_auto_system_msgs::msg::AutowareState::DRIVING) {
+    aw_state == tier4_system_msgs::msg::AutowareState::WAITING_FOR_ENGAGE ||
+    aw_state == tier4_system_msgs::msg::AutowareState::DRIVING) {
     // cancel goal state
     arrived_goal_ = false;
   }

--- a/awapi_awiv_adapter/src/awapi_awiv_adapter_core.cpp
+++ b/awapi_awiv_adapter/src/awapi_awiv_adapter_core.cpp
@@ -82,7 +82,7 @@ AutowareIvAdapter::AutowareIvAdapter()
     "input/battery", 1, std::bind(&AutowareIvAdapter::callbackBattery, this, _1));
   sub_nav_sat_ = this->create_subscription<sensor_msgs::msg::NavSatFix>(
     "input/nav_sat", 1, std::bind(&AutowareIvAdapter::callbackNavSat, this, _1));
-  sub_autoware_state_ = this->create_subscription<autoware_auto_system_msgs::msg::AutowareState>(
+  sub_autoware_state_ = this->create_subscription<tier4_system_msgs::msg::AutowareState>(
     "input/autoware_state", 1, std::bind(&AutowareIvAdapter::callbackAutowareState, this, _1));
   sub_control_mode_ = this->create_subscription<autoware_auto_vehicle_msgs::msg::ControlModeReport>(
     "input/control_mode", 1, std::bind(&AutowareIvAdapter::callbackControlMode, this, _1));
@@ -246,7 +246,7 @@ void AutowareIvAdapter::getCurrentPose()
 }
 
 void AutowareIvAdapter::callbackAutowareState(
-  const autoware_auto_system_msgs::msg::AutowareState::ConstSharedPtr msg_ptr)
+  const tier4_system_msgs::msg::AutowareState::ConstSharedPtr msg_ptr)
 {
   aw_info_.autoware_state_ptr = msg_ptr;
 }


### PR DESCRIPTION
## PR Type

- Bug Fix

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description

FIx to awapi autoware state to match `/api/iv_msgs/autoware/state`

## Review Procedure

Check `autoware_state` of `/awapi/autoware/get/status` is emergency when `/api/iv_msgs/autoware/state` is.

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s).
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
