### PR TITLE
feat: add external adaptor for cpu usage topic

### DIFF
--- a/autoware_iv_external_api_adaptor/CMakeLists.txt
+++ b/autoware_iv_external_api_adaptor/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/cpu_usage.cpp
   src/diagnostics.cpp
   src/door.cpp
   src/emergency.cpp
@@ -31,6 +32,7 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/velocity.cpp
   src/version.cpp
 )
+rclcpp_components_register_nodes(${PROJECT_NAME} "external_api::CpuUsage")
 rclcpp_components_register_nodes(${PROJECT_NAME} "external_api::Diagnostics")
 rclcpp_components_register_nodes(${PROJECT_NAME} "external_api::Door")
 rclcpp_components_register_nodes(${PROJECT_NAME} "external_api::Emergency")

--- a/autoware_iv_external_api_adaptor/src/cpu_usage.cpp
+++ b/autoware_iv_external_api_adaptor/src/cpu_usage.cpp
@@ -1,0 +1,37 @@
+// Copyright 2021 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cpu_usage.hpp"
+#include <memory>
+
+namespace external_api
+{
+
+CpuUsage::CpuUsage(const rclcpp::NodeOptions & options)
+: Node("cpu_usage", options)
+{
+  pub_cpu_usage_ = create_publisher<tier4_external_api_msgs::msg::CpuUsage>(
+    "/api/external/get/cpu_usage", rclcpp::QoS(1));
+  sub_cpu_usage_ = create_subscription<tier4_external_api_msgs::msg::CpuUsage>(
+    "/system/system_monitor/cpu_monitor/cpu_usage", rclcpp::QoS(1),
+    [this](const tier4_external_api_msgs::msg::CpuUsage::SharedPtr msg)
+    {
+      pub_cpu_usage_->publish(*msg);
+    });
+}
+
+}  // namespace external_api
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(external_api::CpuUsage)

--- a/autoware_iv_external_api_adaptor/src/cpu_usage.cpp
+++ b/autoware_iv_external_api_adaptor/src/cpu_usage.cpp
@@ -13,20 +13,19 @@
 // limitations under the License.
 
 #include "cpu_usage.hpp"
+
 #include <memory>
 
 namespace external_api
 {
 
-CpuUsage::CpuUsage(const rclcpp::NodeOptions & options)
-: Node("cpu_usage", options)
+CpuUsage::CpuUsage(const rclcpp::NodeOptions & options) : Node("cpu_usage", options)
 {
   pub_cpu_usage_ = create_publisher<tier4_external_api_msgs::msg::CpuUsage>(
     "/api/external/get/cpu_usage", rclcpp::QoS(1));
   sub_cpu_usage_ = create_subscription<tier4_external_api_msgs::msg::CpuUsage>(
     "/system/system_monitor/cpu_monitor/cpu_usage", rclcpp::QoS(1),
-    [this](const tier4_external_api_msgs::msg::CpuUsage::SharedPtr msg)
-    {
+    [this](const tier4_external_api_msgs::msg::CpuUsage::SharedPtr msg) {
       pub_cpu_usage_->publish(*msg);
     });
 }

--- a/autoware_iv_external_api_adaptor/src/cpu_usage.hpp
+++ b/autoware_iv_external_api_adaptor/src/cpu_usage.hpp
@@ -36,4 +36,4 @@ private:
 
 }  // namespace external_api
 
-#endif  // FAIL_SAFE_STATE_HPP_
+#endif  // CPU_USAGE_HPP_

--- a/autoware_iv_external_api_adaptor/src/cpu_usage.hpp
+++ b/autoware_iv_external_api_adaptor/src/cpu_usage.hpp
@@ -17,6 +17,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "tier4_api_utils/tier4_api_utils.hpp"
+
 #include "tier4_external_api_msgs/msg/cpu_status.hpp"
 #include "tier4_external_api_msgs/msg/cpu_usage.hpp"
 

--- a/autoware_iv_external_api_adaptor/src/cpu_usage.hpp
+++ b/autoware_iv_external_api_adaptor/src/cpu_usage.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef FAIL_SAFE_STATE_HPP_
-#define FAIL_SAFE_STATE_HPP_
+#ifndef CPU_USAGE_HPP_
+#define CPU_USAGE_HPP_
 
 #include "rclcpp/rclcpp.hpp"
 #include "tier4_api_utils/tier4_api_utils.hpp"

--- a/autoware_iv_external_api_adaptor/src/cpu_usage.hpp
+++ b/autoware_iv_external_api_adaptor/src/cpu_usage.hpp
@@ -1,0 +1,38 @@
+// Copyright 2021 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FAIL_SAFE_STATE_HPP_
+#define FAIL_SAFE_STATE_HPP_
+
+#include "rclcpp/rclcpp.hpp"
+#include "tier4_api_utils/tier4_api_utils.hpp"
+#include "tier4_external_api_msgs/msg/cpu_status.hpp"
+#include "tier4_external_api_msgs/msg/cpu_usage.hpp"
+
+namespace external_api
+{
+
+class CpuUsage : public rclcpp::Node
+{
+public:
+  explicit CpuUsage(const rclcpp::NodeOptions & options);
+
+private:
+  rclcpp::Publisher<tier4_external_api_msgs::msg::CpuUsage>::SharedPtr pub_cpu_usage_;
+  rclcpp::Subscription<tier4_external_api_msgs::msg::CpuUsage>::SharedPtr sub_cpu_usage_;
+};
+
+}  // namespace external_api
+
+#endif  // FAIL_SAFE_STATE_HPP_


### PR DESCRIPTION
Signed-off-by: TakumiKozaka-T4 <takumi.kozaka@tier4.jp>

## PR Type

- New Feature

## Related Links

[JIRA link](https://tier4.atlassian.net/browse/T4PB-14131)

## Description
Add external api adaptor for cpu usage message.
The data is used mainly in Field Operator Application.

## Review Procedure

## Remarks

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Code follows [coding guidelines][coding-guidelines]
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [x] All open points are addressed and tracked via issues or tickets
- [x] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s).
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
