### PR TITLE
Add motion factor aggregator

### DIFF
--- a/autoware_external_api_msgs/package.xml
+++ b/autoware_external_api_msgs/package.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-
   <name>autoware_external_api_msgs</name>
   <version>0.0.0</version>
   <description>The autoware_external_api_msgs package</description>
@@ -26,5 +25,4 @@
   <export>
     <build_type>ament_cmake</build_type>
   </export>
-
 </package>

--- a/autoware_iv_external_api_adaptor/package.xml
+++ b/autoware_iv_external_api_adaptor/package.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-
   <name>autoware_iv_external_api_adaptor</name>
   <version>0.0.0</version>
   <description>The autoware_iv_external_api_adaptor package</description>
@@ -30,5 +29,4 @@
   <export>
     <build_type>ament_cmake</build_type>
   </export>
-
 </package>

--- a/autoware_iv_internal_api_adaptor/package.xml
+++ b/autoware_iv_internal_api_adaptor/package.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-
   <name>autoware_iv_internal_api_adaptor</name>
   <version>0.0.0</version>
   <description>The autoware_iv_internal_api_adaptor package</description>
@@ -10,31 +9,36 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
+  <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
+  <depend>autoware_auto_system_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>std_srvs</depend>
   <depend>tier4_api_utils</depend>
+  <depend>tier4_auto_msgs_converter</depend>
   <depend>tier4_control_msgs</depend>
   <depend>tier4_external_api_msgs</depend>
   <depend>tier4_localization_msgs</depend>
+  <depend>tier4_perception_msgs</depend>
   <depend>tier4_planning_msgs</depend>
+  <depend>tier4_system_msgs</depend>
+  <depend>tier4_vehicle_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 
   <!-- for backward compatibility -->
-  <!-- nolint --> <depend>autoware_auto_perception_msgs</depend>
-  <!-- nolint --> <depend>autoware_auto_system_msgs</depend>
-  <!-- nolint --> <depend>tier4_perception_msgs</depend>
-  <!-- nolint --> <depend>tier4_system_msgs</depend>
-  <!-- nolint --> <depend>tier4_vehicle_msgs</depend>
-  <!-- nolint --> <depend>tier4_auto_msgs_converter</depend>
+  <!-- nolint -->
+  <!-- nolint -->
+  <!-- nolint -->
+  <!-- nolint -->
+  <!-- nolint -->
+  <!-- nolint -->
 
   <export>
     <build_type>ament_cmake</build_type>
   </export>
-
 </package>

--- a/awapi_awiv_adapter/CMakeLists.txt
+++ b/awapi_awiv_adapter/CMakeLists.txt
@@ -24,6 +24,7 @@ ament_auto_add_executable(awapi_awiv_adapter
   src/awapi_obstacle_avoidance_state_publisher.cpp
   src/awapi_max_velocity_publisher.cpp
   src/awapi_autoware_util.cpp
+  src/awapi_motion_factor_aggregator.cpp
 )
 
 # workaround to allow deprecated header to build on both galactic and rolling

--- a/awapi_awiv_adapter/Readme.md
+++ b/awapi_awiv_adapter/Readme.md
@@ -132,7 +132,6 @@
 |     | autoware_auto_perception_msgs/TrafficSignal | signal |                      | traffic light color/arrow                                      |
 |     | uint8                                       | judge  | 0:NONE, 1:STOP, 2:GO | go/stop judgment based on the color/arrow of the traffic light |
 
-
 ## put topic
 
 ### /awapi/vehicle/put/velocity

--- a/awapi_awiv_adapter/include/awapi_awiv_adapter/awapi_autoware_state_publisher.hpp
+++ b/awapi_awiv_adapter/include/awapi_awiv_adapter/awapi_autoware_state_publisher.hpp
@@ -65,6 +65,9 @@ private:
   void getStopReasonInfo(
     const tier4_planning_msgs::msg::StopReasonArray::ConstSharedPtr & stop_reason_ptr,
     tier4_api_msgs::msg::AwapiAutowareStatus * status);
+  void getMotionFactorInfo(
+    const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr & motion_factor_ptr,
+    tier4_api_msgs::msg::AwapiAutowareStatus * status);
   void getDiagInfo(const AutowareInfo & aw_info, tier4_api_msgs::msg::AwapiAutowareStatus * status);
   void getErrorDiagInfo(
     const AutowareInfo & aw_info, tier4_api_msgs::msg::AwapiAutowareStatus * status);

--- a/awapi_awiv_adapter/include/awapi_awiv_adapter/awapi_autoware_util.hpp
+++ b/awapi_awiv_adapter/include/awapi_awiv_adapter/awapi_autoware_util.hpp
@@ -36,6 +36,7 @@
 #include <tier4_control_msgs/msg/gate_mode.hpp>
 #include <tier4_planning_msgs/msg/is_avoidance_possible.hpp>
 #include <tier4_planning_msgs/msg/lane_change_status.hpp>
+#include <tier4_planning_msgs/msg/motion_factor_array.hpp>
 #include <tier4_planning_msgs/msg/stop_reason_array.hpp>
 #include <tier4_planning_msgs/msg/velocity_limit.hpp>
 #include <tier4_system_msgs/msg/autoware_state.hpp>
@@ -75,6 +76,7 @@ struct AutowareInfo
   tier4_control_msgs::msg::GateMode::ConstSharedPtr gate_mode_ptr;
   autoware_auto_system_msgs::msg::EmergencyState::ConstSharedPtr emergency_state_ptr;
   autoware_auto_system_msgs::msg::HazardStatusStamped::ConstSharedPtr hazard_status_ptr;
+  tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr motion_factor_ptr;
   tier4_planning_msgs::msg::StopReasonArray::ConstSharedPtr stop_reason_ptr;
   tier4_v2x_msgs::msg::InfrastructureCommandArray::ConstSharedPtr v2x_command_ptr;
   tier4_v2x_msgs::msg::VirtualTrafficLightStateArray::ConstSharedPtr v2x_state_ptr;

--- a/awapi_awiv_adapter/include/awapi_awiv_adapter/awapi_awiv_adapter_core.hpp
+++ b/awapi_awiv_adapter/include/awapi_awiv_adapter/awapi_awiv_adapter_core.hpp
@@ -19,6 +19,7 @@
 #include "awapi_awiv_adapter/awapi_autoware_util.hpp"
 #include "awapi_awiv_adapter/awapi_lane_change_state_publisher.hpp"
 #include "awapi_awiv_adapter/awapi_max_velocity_publisher.hpp"
+#include "awapi_awiv_adapter/awapi_motion_factor_aggregator.hpp"
 #include "awapi_awiv_adapter/awapi_obstacle_avoidance_state_publisher.hpp"
 #include "awapi_awiv_adapter/awapi_stop_reason_aggregator.hpp"
 #include "awapi_awiv_adapter/awapi_v2x_aggregator.hpp"
@@ -39,6 +40,7 @@
 #include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/nav_sat_fix.hpp>
 #include <tier4_control_msgs/msg/gate_mode.hpp>
+#include <tier4_planning_msgs/msg/motion_factor_array.hpp>
 #include <tier4_planning_msgs/msg/stop_reason_array.hpp>
 #include <tier4_system_msgs/msg/autoware_state.hpp>
 #include <tier4_v2x_msgs/msg/infrastructure_command_array.hpp>
@@ -77,6 +79,7 @@ private:
   rclcpp::Subscription<autoware_auto_system_msgs::msg::HazardStatusStamped>::SharedPtr
     sub_hazard_status_;
   rclcpp::Subscription<tier4_planning_msgs::msg::StopReasonArray>::SharedPtr sub_stop_reason_;
+  rclcpp::Subscription<tier4_planning_msgs::msg::MotionFactorArray>::SharedPtr sub_motion_factor_;
   rclcpp::Subscription<tier4_v2x_msgs::msg::InfrastructureCommandArray>::SharedPtr sub_v2x_command_;
   rclcpp::Subscription<tier4_v2x_msgs::msg::VirtualTrafficLightStateArray>::SharedPtr
     sub_v2x_state_;
@@ -129,6 +132,7 @@ private:
   void callbackHazardStatus(
     const autoware_auto_system_msgs::msg::HazardStatusStamped::ConstSharedPtr msg_ptr);
   void callbackStopReason(const tier4_planning_msgs::msg::StopReasonArray::ConstSharedPtr msg_ptr);
+  void callbackMotionFactor(const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr msg_ptr);
   void callbackV2XCommand(
     const tier4_v2x_msgs::msg::InfrastructureCommandArray::ConstSharedPtr msg_ptr);
   void callbackV2XState(
@@ -162,6 +166,7 @@ private:
   std::unique_ptr<AutowareIvVehicleStatePublisher> vehicle_state_publisher_;
   std::unique_ptr<AutowareIvAutowareStatePublisher> autoware_state_publisher_;
   std::unique_ptr<AutowareIvStopReasonAggregator> stop_reason_aggregator_;
+  std::unique_ptr<AutowareIvMotionFactorAggregator> motion_factor_aggregator_;
   std::unique_ptr<AutowareIvV2XAggregator> v2x_aggregator_;
   std::unique_ptr<AutowareIvLaneChangeStatePublisher> lane_change_state_publisher_;
   std::unique_ptr<AutowareIvObstacleAvoidanceStatePublisher> obstacle_avoidance_state_publisher_;

--- a/awapi_awiv_adapter/include/awapi_awiv_adapter/awapi_awiv_adapter_core.hpp
+++ b/awapi_awiv_adapter/include/awapi_awiv_adapter/awapi_awiv_adapter_core.hpp
@@ -79,9 +79,12 @@ private:
   rclcpp::Subscription<autoware_auto_system_msgs::msg::HazardStatusStamped>::SharedPtr
     sub_hazard_status_;
   rclcpp::Subscription<tier4_planning_msgs::msg::StopReasonArray>::SharedPtr sub_stop_reason_;
-  rclcpp::Subscription<tier4_planning_msgs::msg::MotionFactorArray>::SharedPtr sub_scene_module_motion_factor_;
-  rclcpp::Subscription<tier4_planning_msgs::msg::MotionFactorArray>::SharedPtr sub_obstacle_stop_motion_factor_;
-  rclcpp::Subscription<tier4_planning_msgs::msg::MotionFactorArray>::SharedPtr sub_surround_obstacle_motion_factor_;
+  rclcpp::Subscription<tier4_planning_msgs::msg::MotionFactorArray>::SharedPtr
+    sub_scene_module_motion_factor_;
+  rclcpp::Subscription<tier4_planning_msgs::msg::MotionFactorArray>::SharedPtr
+    sub_obstacle_stop_motion_factor_;
+  rclcpp::Subscription<tier4_planning_msgs::msg::MotionFactorArray>::SharedPtr
+    sub_surround_obstacle_motion_factor_;
   rclcpp::Subscription<tier4_v2x_msgs::msg::InfrastructureCommandArray>::SharedPtr sub_v2x_command_;
   rclcpp::Subscription<tier4_v2x_msgs::msg::VirtualTrafficLightStateArray>::SharedPtr
     sub_v2x_state_;
@@ -134,9 +137,12 @@ private:
   void callbackHazardStatus(
     const autoware_auto_system_msgs::msg::HazardStatusStamped::ConstSharedPtr msg_ptr);
   void callbackStopReason(const tier4_planning_msgs::msg::StopReasonArray::ConstSharedPtr msg_ptr);
-  void callbackSceneModuleMotionFactor(const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr msg_ptr);
-  void callbackObstacleStopMotionFactor(const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr msg_ptr);
-  void callbackSurroundObstacleMotionFactor(const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr msg_ptr);
+  void callbackSceneModuleMotionFactor(
+    const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr msg_ptr);
+  void callbackObstacleStopMotionFactor(
+    const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr msg_ptr);
+  void callbackSurroundObstacleMotionFactor(
+    const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr msg_ptr);
   void callbackV2XCommand(
     const tier4_v2x_msgs::msg::InfrastructureCommandArray::ConstSharedPtr msg_ptr);
   void callbackV2XState(
@@ -178,6 +184,7 @@ private:
   double status_pub_hz_;
   double stop_reason_timeout_;
   double stop_reason_thresh_dist_;
+  double motion_factor_timeout_;
 };
 
 }  // namespace autoware_api

--- a/awapi_awiv_adapter/include/awapi_awiv_adapter/awapi_awiv_adapter_core.hpp
+++ b/awapi_awiv_adapter/include/awapi_awiv_adapter/awapi_awiv_adapter_core.hpp
@@ -79,7 +79,9 @@ private:
   rclcpp::Subscription<autoware_auto_system_msgs::msg::HazardStatusStamped>::SharedPtr
     sub_hazard_status_;
   rclcpp::Subscription<tier4_planning_msgs::msg::StopReasonArray>::SharedPtr sub_stop_reason_;
-  rclcpp::Subscription<tier4_planning_msgs::msg::MotionFactorArray>::SharedPtr sub_motion_factor_;
+  rclcpp::Subscription<tier4_planning_msgs::msg::MotionFactorArray>::SharedPtr sub_scene_module_motion_factor_;
+  rclcpp::Subscription<tier4_planning_msgs::msg::MotionFactorArray>::SharedPtr sub_obstacle_stop_motion_factor_;
+  rclcpp::Subscription<tier4_planning_msgs::msg::MotionFactorArray>::SharedPtr sub_surround_obstacle_motion_factor_;
   rclcpp::Subscription<tier4_v2x_msgs::msg::InfrastructureCommandArray>::SharedPtr sub_v2x_command_;
   rclcpp::Subscription<tier4_v2x_msgs::msg::VirtualTrafficLightStateArray>::SharedPtr
     sub_v2x_state_;
@@ -132,7 +134,9 @@ private:
   void callbackHazardStatus(
     const autoware_auto_system_msgs::msg::HazardStatusStamped::ConstSharedPtr msg_ptr);
   void callbackStopReason(const tier4_planning_msgs::msg::StopReasonArray::ConstSharedPtr msg_ptr);
-  void callbackMotionFactor(const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr msg_ptr);
+  void callbackSceneModuleMotionFactor(const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr msg_ptr);
+  void callbackObstacleStopMotionFactor(const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr msg_ptr);
+  void callbackSurroundObstacleMotionFactor(const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr msg_ptr);
   void callbackV2XCommand(
     const tier4_v2x_msgs::msg::InfrastructureCommandArray::ConstSharedPtr msg_ptr);
   void callbackV2XState(

--- a/awapi_awiv_adapter/include/awapi_awiv_adapter/awapi_motion_factor_aggregator.hpp
+++ b/awapi_awiv_adapter/include/awapi_awiv_adapter/awapi_motion_factor_aggregator.hpp
@@ -1,0 +1,64 @@
+// Copyright 2020 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AWAPI_AWIV_ADAPTER__AWAPI_MOTION_FACTOR_AGGREGATOR_HPP_
+#define AWAPI_AWIV_ADAPTER__AWAPI_MOTION_FACTOR_AGGREGATOR_HPP_
+
+#include "awapi_awiv_adapter/awapi_autoware_util.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <vector>
+
+namespace autoware_api
+{
+class AutowareIvMotionFactorAggregator
+{
+public:
+  AutowareIvMotionFactorAggregator(
+    rclcpp::Node & node, const double timeout, const double thresh_dist_to_stop_pose);
+  tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr updateMotionFactorArray(
+    const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr & msg_ptr,
+    const AutowareInfo & aw_info);
+
+private:
+  void applyUpdate(
+    const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr & msg_ptr,
+    const AutowareInfo & aw_info);
+  bool checkMatchingReason(
+    const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr & msg_motion_factor_array,
+    const tier4_planning_msgs::msg::MotionFactorArray & motion_factor_array);
+  void applyTimeOut();
+  void appendMotionFactorToArray(
+    const tier4_planning_msgs::msg::MotionFactor & motion_factor,
+    tier4_planning_msgs::msg::MotionFactorArray * motion_factor_array, const AutowareInfo & aw_info);
+  tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr makeMotionFactorArray(
+    const AutowareInfo & aw_info);
+  tier4_planning_msgs::msg::MotionFactor inputStopDistToMotionFactor(
+    const tier4_planning_msgs::msg::MotionFactor & motion_factor, const AutowareInfo & aw_info);
+  double calcStopDistToStopFactor(
+    const tier4_planning_msgs::msg::StopFactor & stop_factor, const AutowareInfo & aw_info);
+  tier4_planning_msgs::msg::MotionFactor getNearMotionFactor(
+    const tier4_planning_msgs::msg::MotionFactor & motion_factor, const AutowareInfo & aw_info);
+
+  rclcpp::Logger logger_;
+  rclcpp::Clock::SharedPtr clock_;
+  double timeout_;
+  double thresh_dist_to_stop_pose_;
+  std::vector<tier4_planning_msgs::msg::MotionFactorArray> motion_factor_array_vec_;
+};
+
+}  // namespace autoware_api
+
+#endif  // AWAPI_AWIV_ADAPTER__AWAPI_MOTION_FACTOR_AGGREGATOR_HPP_

--- a/awapi_awiv_adapter/include/awapi_awiv_adapter/awapi_motion_factor_aggregator.hpp
+++ b/awapi_awiv_adapter/include/awapi_awiv_adapter/awapi_motion_factor_aggregator.hpp
@@ -26,23 +26,26 @@ namespace autoware_api
 class AutowareIvMotionFactorAggregator
 {
 public:
-  AutowareIvMotionFactorAggregator(rclcpp::Node & node);
-  tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr updateSceneModuleMotionFactorArray(
+  AutowareIvMotionFactorAggregator(rclcpp::Node & node, const double timeout);
+  void updateSceneModuleMotionFactorArray(
     const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr & msg_ptr);
-  tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr updateObstacleStopMotionFactorArray(
+  void updateObstacleStopMotionFactorArray(
     const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr & msg_ptr);
-  tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr updateSurroundObstacleMotionFactorArray(
+  void updateSurroundObstacleMotionFactorArray(
     const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr & msg_ptr);
   tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr makeMotionFactorArray(
     const AutowareInfo & aw_info);
-  
 
 private:
-  static bool compareFactorsByDistance(
-    tier4_planning_msgs::msg::MotionFactor &a, tier4_planning_msgs::msg::MotionFactor &b);
+  void applyUpdate(const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr & msg_ptr);
+  bool checkMatchingReason(
+    const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr & msg_motion_factor_array,
+    const tier4_planning_msgs::msg::MotionFactorArray & motion_factor_array);
+  void applyTimeOut();
   void appendMotionFactorToArray(
     const tier4_planning_msgs::msg::MotionFactor & motion_factor,
-    tier4_planning_msgs::msg::MotionFactorArray * motion_factor_array, const AutowareInfo & aw_info);
+    tier4_planning_msgs::msg::MotionFactorArray * motion_factor_array,
+    const AutowareInfo & aw_info);
   tier4_planning_msgs::msg::MotionFactor inputStopDistToMotionFactor(
     const tier4_planning_msgs::msg::MotionFactor & motion_factor, const AutowareInfo & aw_info);
   double calcStopDistToStopFactor(
@@ -50,10 +53,10 @@ private:
 
   rclcpp::Logger logger_;
   rclcpp::Clock::SharedPtr clock_;
+  double timeout_;
 
   std::vector<tier4_planning_msgs::msg::MotionFactorArray> motion_factor_array_vec_;
-  tier4_planning_msgs::msg::MotionFactorArray scene_module_factor_;
-  tier4_planning_msgs::msg::MotionFactorArray obstcle_stop_factor_;
+  tier4_planning_msgs::msg::MotionFactorArray obstacle_stop_factor_;
   tier4_planning_msgs::msg::MotionFactorArray surround_obstacle_factor_;
 };
 

--- a/awapi_awiv_adapter/include/awapi_awiv_adapter/awapi_motion_factor_aggregator.hpp
+++ b/awapi_awiv_adapter/include/awapi_awiv_adapter/awapi_motion_factor_aggregator.hpp
@@ -26,37 +26,35 @@ namespace autoware_api
 class AutowareIvMotionFactorAggregator
 {
 public:
-  AutowareIvMotionFactorAggregator(
-    rclcpp::Node & node, const double timeout, const double thresh_dist_to_stop_pose);
-  tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr updateMotionFactorArray(
-    const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr & msg_ptr,
+  AutowareIvMotionFactorAggregator(rclcpp::Node & node);
+  tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr updateSceneModuleMotionFactorArray(
+    const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr & msg_ptr);
+  tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr updateObstacleStopMotionFactorArray(
+    const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr & msg_ptr);
+  tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr updateSurroundObstacleMotionFactorArray(
+    const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr & msg_ptr);
+  tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr makeMotionFactorArray(
     const AutowareInfo & aw_info);
+  
 
 private:
-  void applyUpdate(
-    const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr & msg_ptr,
-    const AutowareInfo & aw_info);
-  bool checkMatchingReason(
-    const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr & msg_motion_factor_array,
-    const tier4_planning_msgs::msg::MotionFactorArray & motion_factor_array);
-  void applyTimeOut();
+  static bool compareFactorsByDistance(
+    tier4_planning_msgs::msg::MotionFactor &a, tier4_planning_msgs::msg::MotionFactor &b);
   void appendMotionFactorToArray(
     const tier4_planning_msgs::msg::MotionFactor & motion_factor,
     tier4_planning_msgs::msg::MotionFactorArray * motion_factor_array, const AutowareInfo & aw_info);
-  tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr makeMotionFactorArray(
-    const AutowareInfo & aw_info);
   tier4_planning_msgs::msg::MotionFactor inputStopDistToMotionFactor(
     const tier4_planning_msgs::msg::MotionFactor & motion_factor, const AutowareInfo & aw_info);
   double calcStopDistToStopFactor(
     const tier4_planning_msgs::msg::StopFactor & stop_factor, const AutowareInfo & aw_info);
-  tier4_planning_msgs::msg::MotionFactor getNearMotionFactor(
-    const tier4_planning_msgs::msg::MotionFactor & motion_factor, const AutowareInfo & aw_info);
 
   rclcpp::Logger logger_;
   rclcpp::Clock::SharedPtr clock_;
-  double timeout_;
-  double thresh_dist_to_stop_pose_;
+
   std::vector<tier4_planning_msgs::msg::MotionFactorArray> motion_factor_array_vec_;
+  tier4_planning_msgs::msg::MotionFactorArray scene_module_factor_;
+  tier4_planning_msgs::msg::MotionFactorArray obstcle_stop_factor_;
+  tier4_planning_msgs::msg::MotionFactorArray surround_obstacle_factor_;
 };
 
 }  // namespace autoware_api

--- a/awapi_awiv_adapter/launch/awapi_awiv_adapter.launch.xml
+++ b/awapi_awiv_adapter/launch/awapi_awiv_adapter.launch.xml
@@ -18,8 +18,10 @@
   <arg name="input_gate_mode" default="/control/current_gate_mode" />
   <arg name="input_emergency_state" default="/system/emergency/emergency_state" />
   <arg name="input_hazard_status" default="/system/emergency/hazard_status" />
-  <arg name="input_motion_factor" default="/planning/scenario_planning/status/motion_factors" />
   <arg name="input_stop_reason" default="/planning/scenario_planning/status/stop_reasons" />
+  <arg name="input_scene_module_motion_factor" default="/planning/scenario_planning/status/scene_modules/motion_factors" />
+  <arg name="input_obstacle_stop_motion_factor" default="/planning/scenario_planning/status/obstacle_stop/motion_factors" />
+  <arg name="input_surround_obstacle_motion_factor" default="/planning/scenario_planning/status/surround_obstacle_checker/motion_factors" />
   <arg name="input_v2x_command" default="/planning/scenario_planning/status/infrastructure_commands" />
   <arg name="input_v2x_state" default="/system/v2x/virtual_traffic_light_states" />
   <arg name="input_diagnostics" default="/diagnostics_agg" />
@@ -114,6 +116,9 @@
       <remap from="input/emergency_state" to="$(var input_emergency_state)" />
       <remap from="input/hazard_status" to="$(var input_hazard_status)" />
       <remap from="input/stop_reason" to="$(var input_stop_reason)" />
+      <remap from="input/scene_module/motion_factor" to="$(var input_scene_module_motion_factor)" />
+      <remap from="input/obstacle_stop/motion_factor" to="$(var input_obstacle_stop_motion_factor)" />
+      <remap from="input/surround_obstacle/motion_factor" to="$(var input_surround_obstacle_motion_factor)" />
       <remap from="input/v2x_command" to="$(var input_v2x_command)" />
       <remap from="input/v2x_state" to="$(var input_v2x_state)" />
       <remap from="input/diagnostics" to="$(var input_diagnostics)" />

--- a/awapi_awiv_adapter/launch/awapi_awiv_adapter.launch.xml
+++ b/awapi_awiv_adapter/launch/awapi_awiv_adapter.launch.xml
@@ -1,153 +1,152 @@
 <launch>
-  <arg name="adapter_output" default="screen" />
-  <arg name="relay_output" default="log" />
-  <arg name="status_pub_hz" default="5.0" />
-  <arg name="stop_reason_timeout" default="0.5" />
-  <arg name="stop_reason_thresh_dist" default="100.0" />
+  <arg name="adapter_output" default="screen"/>
+  <arg name="relay_output" default="log"/>
+  <arg name="status_pub_hz" default="5.0"/>
+  <arg name="stop_reason_timeout" default="0.5"/>
+  <arg name="stop_reason_thresh_dist" default="100.0"/>
 
-  <arg name="input_steer" default="/vehicle/status/steering_status" />
-  <arg name="input_vehicle_cmd" default="/control/command/control_cmd" />
-  <arg name="input_turn_indicators" default="/vehicle/status/turn_indicators_status" />
-  <arg name="input_hazard_lights" default="/vehicle/status/hazard_lights_status" />
-  <arg name="input_odometry" default="/localization/kinematic_state" />
-  <arg name="input_gear" default="/vehicle/status/gear_status" />
-  <arg name="input_battery" default="/vehicle/status/battery_charge" />
-  <arg name="input_nav_sat" default="/sensing/gnss/ublox/nav_sat_fix" />
-  <arg name="input_autoware_state" default="/api/iv_msgs/autoware/state" />
-  <arg name="input_control_mode" default="/vehicle/status/control_mode" />
-  <arg name="input_gate_mode" default="/control/current_gate_mode" />
-  <arg name="input_emergency_state" default="/system/emergency/emergency_state" />
-  <arg name="input_hazard_status" default="/system/emergency/hazard_status" />
-  <arg name="input_stop_reason" default="/planning/scenario_planning/status/stop_reasons" />
-  <arg name="input_scene_module_motion_factor" default="/planning/scenario_planning/status/scene_modules/motion_factors" />
-  <arg name="input_obstacle_stop_motion_factor" default="/planning/scenario_planning/status/obstacle_stop/motion_factors" />
-  <arg name="input_surround_obstacle_motion_factor" default="/planning/scenario_planning/status/surround_obstacle_checker/motion_factors" />
-  <arg name="input_v2x_command" default="/planning/scenario_planning/status/infrastructure_commands" />
-  <arg name="input_v2x_state" default="/system/v2x/virtual_traffic_light_states" />
-  <arg name="input_diagnostics" default="/diagnostics_agg" />
-  <arg name="input_lane_change_available" default="/planning/scenario_planning/lane_driving/lane_change_available" />
-  <arg name="input_lane_change_ready" default="/planning/scenario_planning/lane_driving/lane_change_ready" />
-  <arg name="input_lane_change_candidate_path" default="/planning/scenario_planning/lane_driving/lane_change_candidate_path" />
-  <arg name="input_path_change_ready" default="/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/ready_module" />
-  <arg name="input_path_change_force_available" default="/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/force_available" />
-  <arg name="input_path_change_running" default="/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/running_modules" />
-  <arg name="input_obstacle_avoid_ready" default="/planning/scenario_planning/lane_driving/obstacle_avoidance_ready" />
-  <arg name="input_obstacle_avoid_candidate_path" default="/planning/scenario_planning/lane_driving/obstacle_avoidance_candidate_trajectory" />
-  <arg name="input_route" default="/planning/mission_planning/route" />
-  <arg name="input_object" default="/perception/object_recognition/objects" />
-  <arg name="input_traffic_signals" default="/perception/traffic_light_recognition/traffic_signals" />
-  <arg name="input_nearest_traffic_signal" default="/planning/scenario_planning/lane_driving/behavior_planning/debug/traffic_signal" />
-  <arg name="input_trajectory" default="/planning/scenario_planning/trajectory" />
-  <arg name="input_current_max_velocity" default="/planning/scenario_planning/current_max_velocity" />
-  <arg name="input_stop_speed_exceeded" default="/planning/scenario_planning/motion_velocity_smoother/stop_speed_exceeded" />
-  <arg name="input_external_crosswalk_status" default="/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/input/external_crosswalk_states" />
-  <arg name="input_external_intersection_status" default="/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/input/external_intersection_states" />
-  <arg name="input_expand_stop_range" default="/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/input/expand_stop_range" />
-  <arg name="input_pose_initialization_request" default="/localization/util/pose_initialization_request" />
+  <arg name="input_steer" default="/vehicle/status/steering_status"/>
+  <arg name="input_vehicle_cmd" default="/control/command/control_cmd"/>
+  <arg name="input_turn_indicators" default="/vehicle/status/turn_indicators_status"/>
+  <arg name="input_hazard_lights" default="/vehicle/status/hazard_lights_status"/>
+  <arg name="input_odometry" default="/localization/kinematic_state"/>
+  <arg name="input_gear" default="/vehicle/status/gear_status"/>
+  <arg name="input_battery" default="/vehicle/status/battery_charge"/>
+  <arg name="input_nav_sat" default="/sensing/gnss/ublox/nav_sat_fix"/>
+  <arg name="input_autoware_state" default="/api/iv_msgs/autoware/state"/>
+  <arg name="input_control_mode" default="/vehicle/status/control_mode"/>
+  <arg name="input_gate_mode" default="/control/current_gate_mode"/>
+  <arg name="input_emergency_state" default="/system/emergency/emergency_state"/>
+  <arg name="input_hazard_status" default="/system/emergency/hazard_status"/>
+  <arg name="input_stop_reason" default="/planning/scenario_planning/status/stop_reasons"/>
+  <arg name="input_scene_module_motion_factor" default="/planning/scenario_planning/status/scene_modules/motion_factors"/>
+  <arg name="input_obstacle_stop_motion_factor" default="/planning/scenario_planning/status/obstacle_stop/motion_factors"/>
+  <arg name="input_surround_obstacle_motion_factor" default="/planning/scenario_planning/status/surround_obstacle_checker/motion_factors"/>
+  <arg name="input_v2x_command" default="/planning/scenario_planning/status/infrastructure_commands"/>
+  <arg name="input_v2x_state" default="/system/v2x/virtual_traffic_light_states"/>
+  <arg name="input_diagnostics" default="/diagnostics_agg"/>
+  <arg name="input_lane_change_available" default="/planning/scenario_planning/lane_driving/lane_change_available"/>
+  <arg name="input_lane_change_ready" default="/planning/scenario_planning/lane_driving/lane_change_ready"/>
+  <arg name="input_lane_change_candidate_path" default="/planning/scenario_planning/lane_driving/lane_change_candidate_path"/>
+  <arg name="input_path_change_ready" default="/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/ready_module"/>
+  <arg name="input_path_change_force_available" default="/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/force_available"/>
+  <arg name="input_path_change_running" default="/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/running_modules"/>
+  <arg name="input_obstacle_avoid_ready" default="/planning/scenario_planning/lane_driving/obstacle_avoidance_ready"/>
+  <arg name="input_obstacle_avoid_candidate_path" default="/planning/scenario_planning/lane_driving/obstacle_avoidance_candidate_trajectory"/>
+  <arg name="input_route" default="/planning/mission_planning/route"/>
+  <arg name="input_object" default="/perception/object_recognition/objects"/>
+  <arg name="input_traffic_signals" default="/perception/traffic_light_recognition/traffic_signals"/>
+  <arg name="input_nearest_traffic_signal" default="/planning/scenario_planning/lane_driving/behavior_planning/debug/traffic_signal"/>
+  <arg name="input_trajectory" default="/planning/scenario_planning/trajectory"/>
+  <arg name="input_current_max_velocity" default="/planning/scenario_planning/current_max_velocity"/>
+  <arg name="input_stop_speed_exceeded" default="/planning/scenario_planning/motion_velocity_smoother/stop_speed_exceeded"/>
+  <arg name="input_external_crosswalk_status" default="/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/input/external_crosswalk_states"/>
+  <arg name="input_external_intersection_status" default="/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/input/external_intersection_states"/>
+  <arg name="input_expand_stop_range" default="/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/input/expand_stop_range"/>
+  <arg name="input_pose_initialization_request" default="/localization/util/pose_initialization_request"/>
 
-  <arg name="output_vehicle_status" default="vehicle/get/status" />
-  <arg name="output_autoware_status" default="autoware/get/status" />
-  <arg name="output_lane_change_status" default="lane_change/get/status" />
-  <arg name="output_obstacle_avoid_status" default="object_avoidance/get/status" />
-  <arg name="output_max_velocity" default="/planning/scenario_planning/max_velocity_default" />
-  <arg name="output_autoware_engage" default="/autoware/engage" />
-  <arg name="output_vehicle_engage" default="/vehicle/engage" />
-  <arg name="output_goal" default="/planning/mission_planning/goal" />
-  <arg name="output_route" default="/planning/mission_planning/route" />
-  <arg name="output_lane_change_approval" default="/planning/scenario_planning/lane_driving/lane_change_approval" />
-  <arg name="output_force_lane_change" default="/planning/scenario_planning/lane_driving/force_lane_change" />
-  <arg name="output_path_change_approval" default="/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/path_change_approval" />
-  <arg name="output_path_change_force" default="/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/path_change_force" />
-  <arg name="output_obstacle_avoid_approval" default="/planning/scenario_planning/lane_driving/obstacle_avoidance_approval" />
+  <arg name="output_vehicle_status" default="vehicle/get/status"/>
+  <arg name="output_autoware_status" default="autoware/get/status"/>
+  <arg name="output_lane_change_status" default="lane_change/get/status"/>
+  <arg name="output_obstacle_avoid_status" default="object_avoidance/get/status"/>
+  <arg name="output_max_velocity" default="/planning/scenario_planning/max_velocity_default"/>
+  <arg name="output_autoware_engage" default="/autoware/engage"/>
+  <arg name="output_vehicle_engage" default="/vehicle/engage"/>
+  <arg name="output_goal" default="/planning/mission_planning/goal"/>
+  <arg name="output_route" default="/planning/mission_planning/route"/>
+  <arg name="output_lane_change_approval" default="/planning/scenario_planning/lane_driving/lane_change_approval"/>
+  <arg name="output_force_lane_change" default="/planning/scenario_planning/lane_driving/force_lane_change"/>
+  <arg name="output_path_change_approval" default="/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/path_change_approval"/>
+  <arg name="output_path_change_force" default="/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/path_change_force"/>
+  <arg name="output_obstacle_avoid_approval" default="/planning/scenario_planning/lane_driving/obstacle_avoidance_approval"/>
   <!-- output_force_obstacle_avoid is not implemented -->
-  <arg name="output_force_obstacle_avoid" default="tmp" />
-  <arg name="output_overwrite_traffic_signals" default="/external/traffic_light_recognition/traffic_signals" />
+  <arg name="output_force_obstacle_avoid" default="tmp"/>
+  <arg name="output_overwrite_traffic_signals" default="/external/traffic_light_recognition/traffic_signals"/>
 
-  <arg name="node_emergency_stop" default="/control/vehicle_cmd_gate" />
-  <arg name="param_emergency_stop" default="use_external_emergency_stop" />
-  <arg name="node_max_velocity" default="/planning/scenario_planning/motion_velocity_smoother" />
-  <arg name="param_max_velocity" default="max_velocity" />
+  <arg name="node_emergency_stop" default="/control/vehicle_cmd_gate"/>
+  <arg name="param_emergency_stop" default="use_external_emergency_stop"/>
+  <arg name="node_max_velocity" default="/planning/scenario_planning/motion_velocity_smoother"/>
+  <arg name="param_max_velocity" default="max_velocity"/>
 
-  <arg name="set_max_velocity" default="vehicle/put/velocity" />
-  <arg name="set_temporary_stop" default="vehicle/put/stop" />
-  <arg name="set_engage" default="autoware/put/engage" />
-  <arg name="set_route" default="autoware/put/route" />
-  <arg name="set_goal" default="autoware/put/goal" />
-  <arg name="set_lane_change_approval" default="lane_change/put/approval" />
-  <arg name="set_force_lane_change" default="lane_change/put/force" />
-  <arg name="set_path_change_approval" default="path_change/put/approval" />
-  <arg name="set_path_change_force" default="path_change/put/force" />
-  <arg name="set_obstacle_avoid_approval" default="object_avoidance/put/approval" />
-  <arg name="set_force_obstacle_avoid" default="object_avoidance/put/force" />
-  <arg name="set_overwrite_traffic_signals" default="traffic_light/put/traffic_signals" />
-  <arg name="set_crosswalk_status" default="autoware/put/crosswalk_states" />
-  <arg name="set_intersection_status" default="autoware/put/intersection_states" />
-  <arg name="set_expand_stop_range" default="autoware/put/expand_stop_range" />
-  <arg name="set_pose_initialization_request" default="autoware/put/pose_initialization_request" />
+  <arg name="set_max_velocity" default="vehicle/put/velocity"/>
+  <arg name="set_temporary_stop" default="vehicle/put/stop"/>
+  <arg name="set_engage" default="autoware/put/engage"/>
+  <arg name="set_route" default="autoware/put/route"/>
+  <arg name="set_goal" default="autoware/put/goal"/>
+  <arg name="set_lane_change_approval" default="lane_change/put/approval"/>
+  <arg name="set_force_lane_change" default="lane_change/put/force"/>
+  <arg name="set_path_change_approval" default="path_change/put/approval"/>
+  <arg name="set_path_change_force" default="path_change/put/force"/>
+  <arg name="set_obstacle_avoid_approval" default="object_avoidance/put/approval"/>
+  <arg name="set_force_obstacle_avoid" default="object_avoidance/put/force"/>
+  <arg name="set_overwrite_traffic_signals" default="traffic_light/put/traffic_signals"/>
+  <arg name="set_crosswalk_status" default="autoware/put/crosswalk_states"/>
+  <arg name="set_intersection_status" default="autoware/put/intersection_states"/>
+  <arg name="set_expand_stop_range" default="autoware/put/expand_stop_range"/>
+  <arg name="set_pose_initialization_request" default="autoware/put/pose_initialization_request"/>
 
-  <arg name="get_route" default="autoware/get/route" />
-  <arg name="get_predicted_object" default="prediction/get/objects" />
-  <arg name="get_stop_speed_exceeded" default="autoware/get/stop_speed_exceeded" />
-  <arg name="get_traffic_signals" default="traffic_light/get/traffic_signals" />
-  <arg name="get_nearest_traffic_signal" default="traffic_light/get/nearest_traffic_signal" />
-  <arg name="get_v2x_command" default="/awapi/tmp/infrastructure_commands" />
-  <arg name="get_v2x_state" default="/awapi/tmp/virtual_traffic_light_states" />
-  <arg name="get_path_change_ready" default="path_change/get/ready_module" />
-  <arg name="get_path_change_force_available" default="path_change/get/force_available" />
-  <arg name="get_path_change_running" default="path_change/get/running_modules" />
+  <arg name="get_route" default="autoware/get/route"/>
+  <arg name="get_predicted_object" default="prediction/get/objects"/>
+  <arg name="get_stop_speed_exceeded" default="autoware/get/stop_speed_exceeded"/>
+  <arg name="get_traffic_signals" default="traffic_light/get/traffic_signals"/>
+  <arg name="get_nearest_traffic_signal" default="traffic_light/get/nearest_traffic_signal"/>
+  <arg name="get_v2x_command" default="/awapi/tmp/infrastructure_commands"/>
+  <arg name="get_v2x_state" default="/awapi/tmp/virtual_traffic_light_states"/>
+  <arg name="get_path_change_ready" default="path_change/get/ready_module"/>
+  <arg name="get_path_change_force_available" default="path_change/get/force_available"/>
+  <arg name="get_path_change_running" default="path_change/get/running_modules"/>
 
-  <arg name="use_intra_process" default="false" />
-  <arg name="use_multithread" default="false" />
+  <arg name="use_intra_process" default="false"/>
+  <arg name="use_multithread" default="false"/>
 
   <group>
     <push-ros-namespace namespace="awapi"/>
     <node pkg="awapi_awiv_adapter" exec="awapi_awiv_adapter" output="screen">
-      <remap from="input/steer" to="$(var input_steer)" />
-      <remap from="input/vehicle_cmd" to="$(var input_vehicle_cmd)" />
-      <remap from="input/turn_indicators" to="$(var input_turn_indicators)" />
-      <remap from="input/hazard_lights" to="$(var input_hazard_lights)" />
-      <remap from="input/odometry" to="$(var input_odometry)" />
-      <remap from="input/gear" to="$(var input_gear)" />
-      <remap from="input/battery" to="$(var input_battery)" />
-      <remap from="input/nav_sat" to="$(var input_nav_sat)" />
-      <remap from="input/autoware_state" to="$(var input_autoware_state)" />
-      <remap from="input/control_mode" to="$(var input_control_mode)" />
-      <remap from="input/gate_mode" to="$(var input_gate_mode)" />
-      <remap from="input/emergency_state" to="$(var input_emergency_state)" />
-      <remap from="input/hazard_status" to="$(var input_hazard_status)" />
-      <remap from="input/stop_reason" to="$(var input_stop_reason)" />
-      <remap from="input/scene_module/motion_factor" to="$(var input_scene_module_motion_factor)" />
-      <remap from="input/obstacle_stop/motion_factor" to="$(var input_obstacle_stop_motion_factor)" />
-      <remap from="input/surround_obstacle/motion_factor" to="$(var input_surround_obstacle_motion_factor)" />
-      <remap from="input/v2x_command" to="$(var input_v2x_command)" />
-      <remap from="input/v2x_state" to="$(var input_v2x_state)" />
-      <remap from="input/diagnostics" to="$(var input_diagnostics)" />
-      <remap from="input/lane_change_available" to="$(var input_lane_change_available)" />
-      <remap from="input/lane_change_ready" to="$(var input_lane_change_ready)" />
-      <remap from="input/lane_change_candidate_path" to="$(var input_lane_change_candidate_path)" />
-      <remap from="input/obstacle_avoid_ready" to="$(var input_obstacle_avoid_ready)" />
-      <remap from="input/obstacle_avoid_candidate_path" to="$(var input_obstacle_avoid_candidate_path)" />
-      <remap from="input/max_velocity" to="$(var set_max_velocity)" />
-      <remap from="input/current_max_velocity" to="$(var input_current_max_velocity)" />
-      <remap from="input/temporary_stop" to="$(var set_temporary_stop)" />
-      <remap from="input/autoware_trajectory" to="$(var input_trajectory)" />
-      <remap from="output/vehicle_status" to="$(var output_vehicle_status)" />
-      <remap from="output/autoware_status" to="$(var output_autoware_status)" />
-      <remap from="output/lane_change_status" to="$(var output_lane_change_status)" />
-      <remap from="output/obstacle_avoid_status" to="$(var output_obstacle_avoid_status)" />
-      <remap from="output/max_velocity" to="$(var output_max_velocity)" />
-      <remap from="output/v2x_command" to="$(var get_v2x_command)" />
-      <remap from="output/v2x_state" to="$(var get_v2x_state)" />
-      <param name="node/emergency_stop" value="$(var node_emergency_stop)" />
-      <param name="param/emergency_stop" value="$(var param_emergency_stop)" />
-      <param name="node/max_velocity" value="$(var node_max_velocity)" />
-      <param name="param/max_velocity" value="$(var param_max_velocity)" />
-      <param name="status_pub_hz" value="$(var status_pub_hz)" />
-      <param name="stop_reason_timeout" value="$(var stop_reason_timeout)" />
-      <param name="stop_reason_thresh_dist" value="$(var stop_reason_thresh_dist)" />
+      <remap from="input/steer" to="$(var input_steer)"/>
+      <remap from="input/vehicle_cmd" to="$(var input_vehicle_cmd)"/>
+      <remap from="input/turn_indicators" to="$(var input_turn_indicators)"/>
+      <remap from="input/hazard_lights" to="$(var input_hazard_lights)"/>
+      <remap from="input/odometry" to="$(var input_odometry)"/>
+      <remap from="input/gear" to="$(var input_gear)"/>
+      <remap from="input/battery" to="$(var input_battery)"/>
+      <remap from="input/nav_sat" to="$(var input_nav_sat)"/>
+      <remap from="input/autoware_state" to="$(var input_autoware_state)"/>
+      <remap from="input/control_mode" to="$(var input_control_mode)"/>
+      <remap from="input/gate_mode" to="$(var input_gate_mode)"/>
+      <remap from="input/emergency_state" to="$(var input_emergency_state)"/>
+      <remap from="input/hazard_status" to="$(var input_hazard_status)"/>
+      <remap from="input/stop_reason" to="$(var input_stop_reason)"/>
+      <remap from="input/scene_module/motion_factor" to="$(var input_scene_module_motion_factor)"/>
+      <remap from="input/obstacle_stop/motion_factor" to="$(var input_obstacle_stop_motion_factor)"/>
+      <remap from="input/surround_obstacle/motion_factor" to="$(var input_surround_obstacle_motion_factor)"/>
+      <remap from="input/v2x_command" to="$(var input_v2x_command)"/>
+      <remap from="input/v2x_state" to="$(var input_v2x_state)"/>
+      <remap from="input/diagnostics" to="$(var input_diagnostics)"/>
+      <remap from="input/lane_change_available" to="$(var input_lane_change_available)"/>
+      <remap from="input/lane_change_ready" to="$(var input_lane_change_ready)"/>
+      <remap from="input/lane_change_candidate_path" to="$(var input_lane_change_candidate_path)"/>
+      <remap from="input/obstacle_avoid_ready" to="$(var input_obstacle_avoid_ready)"/>
+      <remap from="input/obstacle_avoid_candidate_path" to="$(var input_obstacle_avoid_candidate_path)"/>
+      <remap from="input/max_velocity" to="$(var set_max_velocity)"/>
+      <remap from="input/current_max_velocity" to="$(var input_current_max_velocity)"/>
+      <remap from="input/temporary_stop" to="$(var set_temporary_stop)"/>
+      <remap from="input/autoware_trajectory" to="$(var input_trajectory)"/>
+      <remap from="output/vehicle_status" to="$(var output_vehicle_status)"/>
+      <remap from="output/autoware_status" to="$(var output_autoware_status)"/>
+      <remap from="output/lane_change_status" to="$(var output_lane_change_status)"/>
+      <remap from="output/obstacle_avoid_status" to="$(var output_obstacle_avoid_status)"/>
+      <remap from="output/max_velocity" to="$(var output_max_velocity)"/>
+      <remap from="output/v2x_command" to="$(var get_v2x_command)"/>
+      <remap from="output/v2x_state" to="$(var get_v2x_state)"/>
+      <param name="node/emergency_stop" value="$(var node_emergency_stop)"/>
+      <param name="param/emergency_stop" value="$(var param_emergency_stop)"/>
+      <param name="node/max_velocity" value="$(var node_max_velocity)"/>
+      <param name="param/max_velocity" value="$(var param_max_velocity)"/>
+      <param name="status_pub_hz" value="$(var status_pub_hz)"/>
+      <param name="stop_reason_timeout" value="$(var stop_reason_timeout)"/>
+      <param name="stop_reason_thresh_dist" value="$(var stop_reason_thresh_dist)"/>
     </node>
   </group>
 
-  <include file="$(find-pkg-share awapi_awiv_adapter)/launch/awapi_relay_container.launch.py" />
-
+  <include file="$(find-pkg-share awapi_awiv_adapter)/launch/awapi_relay_container.launch.py"/>
 </launch>

--- a/awapi_awiv_adapter/launch/awapi_awiv_adapter.launch.xml
+++ b/awapi_awiv_adapter/launch/awapi_awiv_adapter.launch.xml
@@ -18,6 +18,7 @@
   <arg name="input_gate_mode" default="/control/current_gate_mode" />
   <arg name="input_emergency_state" default="/system/emergency/emergency_state" />
   <arg name="input_hazard_status" default="/system/emergency/hazard_status" />
+  <arg name="input_motion_factor" default="/planning/scenario_planning/status/motion_factors" />
   <arg name="input_stop_reason" default="/planning/scenario_planning/status/stop_reasons" />
   <arg name="input_v2x_command" default="/planning/scenario_planning/status/infrastructure_commands" />
   <arg name="input_v2x_state" default="/system/v2x/virtual_traffic_light_states" />

--- a/awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp
+++ b/awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp
@@ -49,6 +49,7 @@ void AutowareIvAutowareStatePublisher::statePublisher(const AutowareInfo & aw_in
   getCurrentMaxVelInfo(aw_info.current_max_velocity_ptr, &status);
   getHazardStatusInfo(aw_info, &status);
   getStopReasonInfo(aw_info.stop_reason_ptr, &status);
+  getMotionFactorInfo(aw_info.motion_factor_ptr, &status);
   getDiagInfo(aw_info, &status);
   getErrorDiagInfo(aw_info, &status);
 
@@ -178,6 +179,18 @@ void AutowareIvAutowareStatePublisher::getStopReasonInfo(
   }
 
   status->stop_reason = *stop_reason_ptr;
+}
+
+void AutowareIvAutowareStatePublisher::getMotionFactorInfo(
+  const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr & motion_factor_ptr,
+  tier4_api_msgs::msg::AwapiAutowareStatus * status)
+{
+  if (!motion_factor_ptr) {
+    RCLCPP_DEBUG_STREAM_THROTTLE(logger_, *clock_, 5000 /* ms */, "motion factor is nullptr");
+    return;
+  }
+
+  status->motion_factor = *motion_factor_ptr;
 }
 
 void AutowareIvAutowareStatePublisher::getDiagInfo(

--- a/awapi_awiv_adapter/src/awapi_awiv_adapter_core.cpp
+++ b/awapi_awiv_adapter/src/awapi_awiv_adapter_core.cpp
@@ -41,6 +41,7 @@ AutowareIvAdapter::AutowareIvAdapter()
   autoware_state_publisher_ = std::make_unique<AutowareIvAutowareStatePublisher>(*this);
   stop_reason_aggregator_ = std::make_unique<AutowareIvStopReasonAggregator>(
     *this, stop_reason_timeout_, stop_reason_thresh_dist_);
+  motion_factor_aggregator_ = std::make_unique<AutowareIvMotionFactorAggregator>(*this);
   v2x_aggregator_ = std::make_unique<AutowareIvV2XAggregator>(*this);
   lane_change_state_publisher_ = std::make_unique<AutowareIvLaneChangeStatePublisher>(*this);
   obstacle_avoidance_state_publisher_ =
@@ -91,6 +92,8 @@ AutowareIvAdapter::AutowareIvAdapter()
       "input/hazard_status", 1, std::bind(&AutowareIvAdapter::callbackHazardStatus, this, _1));
   sub_stop_reason_ = this->create_subscription<tier4_planning_msgs::msg::StopReasonArray>(
     "input/stop_reason", 100, std::bind(&AutowareIvAdapter::callbackStopReason, this, _1));
+  sub_motion_factor_ = this->create_subscription<tier4_planning_msgs::msg::MotionFactorArray>(
+    "input/motion_factor", 100, std::bind(&AutowareIvAdapter::callbackMotionFactor, this, _1));
   sub_v2x_command_ = this->create_subscription<tier4_v2x_msgs::msg::InfrastructureCommandArray>(
     "input/v2x_command", 100, std::bind(&AutowareIvAdapter::callbackV2XCommand, this, _1));
   sub_v2x_state_ = this->create_subscription<tier4_v2x_msgs::msg::VirtualTrafficLightStateArray>(
@@ -265,6 +268,12 @@ void AutowareIvAdapter::callbackStopReason(
   const tier4_planning_msgs::msg::StopReasonArray::ConstSharedPtr msg_ptr)
 {
   aw_info_.stop_reason_ptr = stop_reason_aggregator_->updateStopReasonArray(msg_ptr, aw_info_);
+}
+
+void AutowareIvAdapter::callbackMotionFactor(
+  const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr msg_ptr)
+{
+  aw_info_.motion_factor_ptr = motion_factor_aggregator_->updateMotionFactorArray(msg_ptr, aw_info_);
 }
 
 void AutowareIvAdapter::callbackV2XCommand(

--- a/awapi_awiv_adapter/src/awapi_awiv_adapter_core.cpp
+++ b/awapi_awiv_adapter/src/awapi_awiv_adapter_core.cpp
@@ -92,8 +92,12 @@ AutowareIvAdapter::AutowareIvAdapter()
       "input/hazard_status", 1, std::bind(&AutowareIvAdapter::callbackHazardStatus, this, _1));
   sub_stop_reason_ = this->create_subscription<tier4_planning_msgs::msg::StopReasonArray>(
     "input/stop_reason", 100, std::bind(&AutowareIvAdapter::callbackStopReason, this, _1));
-  sub_motion_factor_ = this->create_subscription<tier4_planning_msgs::msg::MotionFactorArray>(
-    "input/motion_factor", 100, std::bind(&AutowareIvAdapter::callbackMotionFactor, this, _1));
+  sub_scene_module_motion_factor_ = this->create_subscription<tier4_planning_msgs::msg::MotionFactorArray>(
+    "input/scene_module/motion_factor", 100, std::bind(&AutowareIvAdapter::callbackSceneModuleMotionFactor, this, _1));
+  sub_obstacle_stop_motion_factor_ = this->create_subscription<tier4_planning_msgs::msg::MotionFactorArray>(
+    "input/obstacle_stop/motion_factor", 100, std::bind(&AutowareIvAdapter::callbackObstacleStopMotionFactor, this, _1));
+  sub_surround_obstacle_motion_factor_ = this->create_subscription<tier4_planning_msgs::msg::MotionFactorArray>(
+    "input/surround_obstacle/motion_factor", 100, std::bind(&AutowareIvAdapter::callbackSurroundObstacleMotionFactor, this, _1));
   sub_v2x_command_ = this->create_subscription<tier4_v2x_msgs::msg::InfrastructureCommandArray>(
     "input/v2x_command", 100, std::bind(&AutowareIvAdapter::callbackV2XCommand, this, _1));
   sub_v2x_state_ = this->create_subscription<tier4_v2x_msgs::msg::VirtualTrafficLightStateArray>(
@@ -150,6 +154,9 @@ void AutowareIvAdapter::timerCallback()
 {
   // get current pose
   getCurrentPose();
+
+  // 
+  aw_info_.motion_factor_ptr = motion_factor_aggregator_->makeMotionFactorArray(aw_info_);
 
   // publish vehicle state
   vehicle_state_publisher_->statePublisher(aw_info_);
@@ -270,10 +277,22 @@ void AutowareIvAdapter::callbackStopReason(
   aw_info_.stop_reason_ptr = stop_reason_aggregator_->updateStopReasonArray(msg_ptr, aw_info_);
 }
 
-void AutowareIvAdapter::callbackMotionFactor(
+void AutowareIvAdapter::callbackSceneModuleMotionFactor(
   const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr msg_ptr)
 {
-  aw_info_.motion_factor_ptr = motion_factor_aggregator_->updateMotionFactorArray(msg_ptr, aw_info_);
+  motion_factor_aggregator_->updateSceneModuleMotionFactorArray(msg_ptr);
+}
+
+void AutowareIvAdapter::callbackObstacleStopMotionFactor(
+  const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr msg_ptr)
+{
+  motion_factor_aggregator_->updateObstacleStopMotionFactorArray(msg_ptr);
+}
+
+void AutowareIvAdapter::callbackSurroundObstacleMotionFactor(
+  const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr msg_ptr)
+{
+  motion_factor_aggregator_->updateSurroundObstacleMotionFactorArray(msg_ptr);
 }
 
 void AutowareIvAdapter::callbackV2XCommand(

--- a/awapi_awiv_adapter/src/awapi_motion_factor_aggregator.cpp
+++ b/awapi_awiv_adapter/src/awapi_motion_factor_aggregator.cpp
@@ -19,28 +19,33 @@
 
 namespace autoware_api
 {
-AutowareIvMotionFactorAggregator::AutowareIvMotionFactorAggregator(rclcpp::Node & node)
+
+bool compareFactorsByDistance(
+  tier4_planning_msgs::msg::MotionFactor & a, tier4_planning_msgs::msg::MotionFactor & b)
+{
+  return a.dist_to_stop_pose < b.dist_to_stop_pose;
+}
+
+AutowareIvMotionFactorAggregator::AutowareIvMotionFactorAggregator(
+  rclcpp::Node & node, const double timeout)
 : logger_(node.get_logger().get_child("awapi_awiv_motion_factor_aggregator")),
   clock_(node.get_clock()),
+  timeout_(timeout)
 {
 }
 
 void AutowareIvMotionFactorAggregator::updateSceneModuleMotionFactorArray(
   const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr & msg_ptr)
 {
-  if(!scene_module_factor_.empty())
-  {
-    scene_module_factor_.clear();
-  }
-  scene_module_factor_ = *msg_ptr;
+  applyUpdate(msg_ptr);
+  applyTimeOut();
 }
 
 void AutowareIvMotionFactorAggregator::updateObstacleStopMotionFactorArray(
   const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr & msg_ptr)
 {
-  if(!obstacle_stop_factor_.empty())
-  {
-    obstacle_stop_factor_.clear();
+  if (!obstacle_stop_factor_.motion_factors.empty()) {
+    obstacle_stop_factor_.motion_factors.clear();
   }
   obstacle_stop_factor_ = *msg_ptr;
 }
@@ -48,11 +53,71 @@ void AutowareIvMotionFactorAggregator::updateObstacleStopMotionFactorArray(
 void AutowareIvMotionFactorAggregator::updateSurroundObstacleMotionFactorArray(
   const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr & msg_ptr)
 {
-  if(!surround_obstacle_factor_.empty())
-  {
-    surround_obstacle_factor_.clear();
+  if (!surround_obstacle_factor_.motion_factors.empty()) {
+    surround_obstacle_factor_.motion_factors.clear();
   }
   surround_obstacle_factor_ = *msg_ptr;
+}
+
+void AutowareIvMotionFactorAggregator::applyUpdate(
+  const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr & msg_ptr)
+{
+  /* remove old motion factor that matches reason with received msg */
+  // make reason-matching msg list
+
+  std::vector<size_t> remove_idx;
+  if (!motion_factor_array_vec_.empty()) {
+    for (int i = motion_factor_array_vec_.size() - 1; i >= 0; i--) {
+      if (checkMatchingReason(msg_ptr, motion_factor_array_vec_.at(i))) {
+        remove_idx.emplace_back(i);
+      }
+    }
+  }
+
+  // remove reason matching msg
+  for (const auto idx : remove_idx) {
+    motion_factor_array_vec_.erase(motion_factor_array_vec_.begin() + idx);
+  }
+
+  // add new reason msg
+  motion_factor_array_vec_.emplace_back(*msg_ptr);
+}
+
+bool AutowareIvMotionFactorAggregator::checkMatchingReason(
+  const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr & msg_motion_factor_array,
+  const tier4_planning_msgs::msg::MotionFactorArray & motion_factor_array)
+{
+  for (const auto & msg_motion_factor : msg_motion_factor_array->motion_factors) {
+    for (const auto & motion_factor : motion_factor_array.motion_factors) {
+      if (msg_motion_factor.reason == motion_factor.reason) {
+        // find matching reason
+        return true;
+      }
+    }
+  }
+  // cannot find matching reason
+  return false;
+}
+
+void AutowareIvMotionFactorAggregator::applyTimeOut()
+{
+  const auto current_time = clock_->now();
+
+  // make timeout-msg list
+  std::vector<size_t> remove_idx;
+  if (!motion_factor_array_vec_.empty()) {
+    for (int i = motion_factor_array_vec_.size() - 1; i >= 0; i--) {
+      if (
+        (current_time - rclcpp::Time(motion_factor_array_vec_.at(i).header.stamp)).seconds() >
+        timeout_) {
+        remove_idx.emplace_back(i);
+      }
+    }
+  }
+  // remove timeout-msg
+  for (const auto idx : remove_idx) {
+    motion_factor_array_vec_.erase(motion_factor_array_vec_.begin() + idx);
+  }
 }
 
 tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr
@@ -64,29 +129,33 @@ AutowareIvMotionFactorAggregator::makeMotionFactorArray(const AutowareInfo & aw_
   motion_factor_array_msg.header.stamp = clock_->now();
 
   // input motion factor
-  for (const auto & motion_factor : scene_module_factor.motion_factors) {
+  for (const auto & motion_factor_array : motion_factor_array_vec_) {
+    for (const auto & motion_factor : motion_factor_array.motion_factors) {
+      appendMotionFactorToArray(motion_factor, &motion_factor_array_msg, aw_info);
+    }
+  }
+
+  for (const auto & motion_factor : obstacle_stop_factor_.motion_factors) {
     appendMotionFactorToArray(motion_factor, &motion_factor_array_msg, aw_info);
   }
 
-  for (const auto & motion_factor : obstacle_factor.motion_factors) {
-    appendMotionFactorToArray(motion_factor, &motion_factor_array_msg, aw_info);
-  }
-
-  for (const auto & motion_factor : surround_obstacle_factor.motion_factors) {
+  for (const auto & motion_factor : surround_obstacle_factor_.motion_factors) {
     appendMotionFactorToArray(motion_factor, &motion_factor_array_msg, aw_info);
   }
 
   // sort factors in ascending order
-  std::sort(motion_factor_array_msg.begin(), motion_factor_array_msg.end(), compareFactorsByDistance);
+  std::sort(
+    motion_factor_array_msg.motion_factors.begin(), motion_factor_array_msg.motion_factors.end(),
+    compareFactorsByDistance);
 
   return std::make_shared<tier4_planning_msgs::msg::MotionFactorArray>(motion_factor_array_msg);
 }
 
-static bool AutowareIvMotionFactorAggregator::compareFactorsByDistance(
-  tier4_planning_msgs::msg::MotionFactor &a, tier4_planning_msgs::msg::MotionFactor &b)
-{
-  return a.dist_to_stop_pose < b.dist_to_stop_pose;
-}
+// bool AutowareIvMotionFactorAggregator::compareFactorsByDistance(
+//   tier4_planning_msgs::msg::MotionFactor &a, tier4_planning_msgs::msg::MotionFactor &b)
+// {
+//   return a.dist_to_stop_pose < b.dist_to_stop_pose;
+// }
 
 void AutowareIvMotionFactorAggregator::appendMotionFactorToArray(
   const tier4_planning_msgs::msg::MotionFactor & motion_factor,
@@ -99,7 +168,8 @@ void AutowareIvMotionFactorAggregator::appendMotionFactorToArray(
   motion_factor_array->motion_factors.emplace_back(motion_factor_with_dist);
 }
 
-tier4_planning_msgs::msg::MotionFactor AutowareIvMotionFactorAggregator::inputStopDistToMotionFactor(
+tier4_planning_msgs::msg::MotionFactor
+AutowareIvMotionFactorAggregator::inputStopDistToMotionFactor(
   const tier4_planning_msgs::msg::MotionFactor & motion_factor, const AutowareInfo & aw_info)
 {
   if (!aw_info.autoware_planning_traj_ptr || !aw_info.current_pose_ptr) {
@@ -110,9 +180,9 @@ tier4_planning_msgs::msg::MotionFactor AutowareIvMotionFactorAggregator::inputSt
   auto motion_factor_with_dist = motion_factor;
   const auto & trajectory = *aw_info.autoware_planning_traj_ptr;
   const auto & current_pose = aw_info.current_pose_ptr->pose;
-  motion_factor.dist_to_stop_pose =
-    planning_util::calcDistanceAlongTrajectory(trajectory, current_pose, motion_factor.stop_pose);
-  
+  motion_factor_with_dist.dist_to_stop_pose = planning_util::calcDistanceAlongTrajectory(
+    trajectory, current_pose, motion_factor_with_dist.stop_pose);
+
   return motion_factor_with_dist;
 }
 

--- a/awapi_awiv_adapter/src/awapi_motion_factor_aggregator.cpp
+++ b/awapi_awiv_adapter/src/awapi_motion_factor_aggregator.cpp
@@ -1,0 +1,185 @@
+// Copyright 2020 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "awapi_awiv_adapter/awapi_motion_factor_aggregator.hpp"
+
+#include <memory>
+#include <vector>
+
+namespace autoware_api
+{
+AutowareIvMotionFactorAggregator::AutowareIvMotionFactorAggregator(
+  rclcpp::Node & node, const double timeout, const double thresh_dist_to_stop_pose)
+: logger_(node.get_logger().get_child("awapi_awiv_motion_factor_aggregator")),
+  clock_(node.get_clock()),
+  timeout_(timeout),
+  thresh_dist_to_stop_pose_(thresh_dist_to_stop_pose)
+{
+}
+
+tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr
+AutowareIvMotionFactorAggregator::updateMotionFactorArray(
+  const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr & msg_ptr,
+  const AutowareInfo & aw_info)
+{
+  applyUpdate(msg_ptr, aw_info);
+  applyTimeOut();
+  return makeMotionFactorArray(aw_info);
+}
+
+void AutowareIvMotionFactorAggregator::applyUpdate(
+  const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr & msg_ptr,
+  [[maybe_unused]] const AutowareInfo & aw_info)
+{
+  /* remove old motion_factor that matches reason with received msg */
+  // make reason-matching msg list
+
+  std::vector<size_t> remove_idx;
+  if (!motion_factor_array_vec_.empty()) {
+    for (int i = motion_factor_array_vec_.size() - 1; i >= 0; i--) {
+      if (checkMatchingReason(msg_ptr, motion_factor_array_vec_.at(i))) {
+        remove_idx.emplace_back(i);
+      }
+    }
+  }
+
+  // remove reason matching msg
+  for (const auto idx : remove_idx) {
+    motion_factor_array_vec_.erase(motion_factor_array_vec_.begin() + idx);
+  }
+
+  // add new reason msg
+  motion_factor_array_vec_.emplace_back(*msg_ptr);
+}
+
+bool AutowareIvMotionFactorAggregator::checkMatchingReason(
+  const tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr & msg_motion_factor_array,
+  const tier4_planning_msgs::msg::MotionFactorArray & motion_factor_array)
+{
+  for (const auto & msg_motion_factor : msg_motion_factor_array->motion_factors) {
+    for (const auto & motion_factor : motion_factor_array.motion_factors) {
+      if (msg_motion_factor.reason == motion_factor.reason) {
+        // find matching reason
+        return true;
+      }
+    }
+  }
+  // cannot find matching reason
+  return false;
+}
+
+void AutowareIvMotionFactorAggregator::applyTimeOut()
+{
+  const auto current_time = clock_->now();
+
+  // make timeout-msg list
+  std::vector<size_t> remove_idx;
+  if (!motion_factor_array_vec_.empty()) {
+    for (int i = motion_factor_array_vec_.size() - 1; i >= 0; i--) {
+      if (
+        (current_time - rclcpp::Time(motion_factor_array_vec_.at(i).header.stamp)).seconds() >
+        timeout_) {
+        remove_idx.emplace_back(i);
+      }
+    }
+  }
+  // remove timeout-msg
+  for (const auto idx : remove_idx) {
+    motion_factor_array_vec_.erase(motion_factor_array_vec_.begin() + idx);
+  }
+}
+
+void AutowareIvMotionFactorAggregator::appendMotionFactorToArray(
+  const tier4_planning_msgs::msg::MotionFactor & motion_factor,
+  tier4_planning_msgs::msg::MotionFactorArray * motion_factor_array, const AutowareInfo & aw_info)
+{
+  // calculate dist_to_stop_pose
+  const auto motion_factor_with_dist = inputStopDistToMotionFactor(motion_factor, aw_info);
+
+  // cut stop reason
+  const auto near_motion_factor = getNearMotionFactor(motion_factor_with_dist, aw_info);
+
+  // if stop factors is empty, not append
+  if (near_motion_factor.stop_factors.empty()) {
+    return;
+  }
+
+  // if already exists same reason msg in motion_factor_array_msg, append stop_factors to there
+  for (auto & base_motion_factors : motion_factor_array->motion_factors) {
+    if (base_motion_factors.reason == near_motion_factor.reason) {
+      base_motion_factors.stop_factors.insert(
+        base_motion_factors.stop_factors.end(), near_motion_factor.stop_factors.begin(),
+        near_motion_factor.stop_factors.end());
+      return;
+    }
+  }
+
+  // if not exist same reason msg, append new stop reason
+  motion_factor_array->motion_factors.emplace_back(near_motion_factor);
+}
+
+tier4_planning_msgs::msg::MotionFactorArray::ConstSharedPtr
+AutowareIvMotionFactorAggregator::makeMotionFactorArray(const AutowareInfo & aw_info)
+{
+  tier4_planning_msgs::msg::MotionFactorArray motion_factor_array_msg;
+  // input header
+  motion_factor_array_msg.header.frame_id = "map";
+  motion_factor_array_msg.header.stamp = clock_->now();
+
+  // input motion factor
+  for (const auto & motion_factor_array : motion_factor_array_vec_) {
+    for (const auto & motion_factor : motion_factor_array.motion_factors) {
+      appendMotionFactorToArray(motion_factor, &motion_factor_array_msg, aw_info);
+    }
+  }
+  return std::make_shared<tier4_planning_msgs::msg::MotionFactorArray>(motion_factor_array_msg);
+}
+
+tier4_planning_msgs::msg::MotionFactor AutowareIvMotionFactorAggregator::inputStopDistToMotionFactor(
+  const tier4_planning_msgs::msg::MotionFactor & motion_factor, const AutowareInfo & aw_info)
+{
+  if (!aw_info.autoware_planning_traj_ptr || !aw_info.current_pose_ptr) {
+    // pass through all stop reason
+    return motion_factor;
+  }
+
+  auto motion_factor_with_dist = motion_factor;
+  const auto & trajectory = *aw_info.autoware_planning_traj_ptr;
+  const auto & current_pose = aw_info.current_pose_ptr->pose;
+  motion_factor.dist_to_stop_pose =
+    planning_util::calcDistanceAlongTrajectory(trajectory, current_pose, motion_factor.stop_pose);
+  
+  return motion_factor_with_dist;
+}
+
+tier4_planning_msgs::msg::MotionFactor AutowareIvMotionFactorAggregator::getNearMotionFactor(
+  const tier4_planning_msgs::msg::MotionFactor & motion_factor, const AutowareInfo & aw_info)
+{
+  if (!aw_info.autoware_planning_traj_ptr || !aw_info.current_pose_ptr) {
+    // pass through all stop reason
+    return motion_factor;
+  }
+
+  tier4_planning_msgs::msg::MotionFactor near_motion_factor;
+  near_motion_factor.reason = motion_factor.reason;
+  for (const auto & stop_factor : motion_factor.stop_factors) {
+    if (stop_factor.dist_to_stop_pose < thresh_dist_to_stop_pose_) {
+      // append only near stop factor
+      near_motion_factor.stop_factors.emplace_back(stop_factor);
+    }
+  }
+  return near_motion_factor;
+}
+
+}  // namespace autoware_api


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- New Feature

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->
https://github.com/autowarefoundation/autoware.universe/pull/723

## Description

<!-- Describe what this PR changes. -->
Add aggregator for the new message "motion factor". The purpose of the aggregator is to output motion factor to external applications.

## Review Procedure

<!-- Explain how to review this PR. -->
1. Run planning simulator.
2. Put initial pose and goal.
3. Run the command `ros2 topic echo /awapi/autoware/get/status`

motion factors are added in the status as follows:
```
motion_factor:
  header:
    stamp:
      sec: 1653373919
      nanosec: 672137914
    frame_id: map
  motion_factors:
  - reason: 1
    state: 0
    stop_pose:
      position:
        x: 0.0
        y: 0.0
        z: 0.0
      orientation:
        x: 0.0
        y: 0.0
        z: 0.0
        w: 1.0
    dist_to_stop_pose: 1.7976931348623157e+308
    stop_factor_points: []
```

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Code follows [coding guidelines][coding-guidelines]
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s).
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
