### PR TITLE
change energy level default value for rclpy bug on humble

### DIFF
--- a/awapi_awiv_adapter/src/awapi_vehicle_state_publisher.cpp
+++ b/awapi_awiv_adapter/src/awapi_vehicle_state_publisher.cpp
@@ -57,9 +57,8 @@ tier4_api_msgs::msg::AwapiVehicleStatus AutowareIvVehicleStatePublisher::initVeh
 {
   tier4_api_msgs::msg::AwapiVehicleStatus status;
   // set default value
-  if (std::numeric_limits<float>::has_quiet_NaN) {
-    status.energy_level = std::numeric_limits<float>::quiet_NaN();
-  }
+  status.energy_level = -1;
+  
   return status;
 }
 


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Bug Fix

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description

If subscribing NaN value on humble rclpy(version 3.3.4), rclpy is broken.
So I suggest to change energy level default value to -1.

<!-- Describe what this PR changes. -->

## Review Procedure
- Execute below code and autoware.
- Initial pose
- Below code is down when default value is NaN, but operate normally when default value is -1.

```py
import rclpy
from rclpy.node import Node
# from std_msgs.msg import String
from tier4_api_msgs.msg import AwapiVehicleStatus


# Nodeクラスを継承
class Listener(Node):
    def __init__(self):
        # 引数node_nameにlistenerを渡す。
        super().__init__("listener")
        
        sub_qos = rclpy.qos.QoSProfile(
            history=rclpy.qos.QoSHistoryPolicy.KEEP_LAST,
            depth=10,
            reliability=rclpy.qos.QoSReliabilityPolicy.BEST_EFFORT,
            durability=rclpy.qos.QoSDurabilityPolicy.SYSTEM_DEFAULT,
        )

        # 引数msg_type、topic_name、callbackに渡してSubscriptionを作成
        # self.create_subscription(String, "chatter", self.callback)
        self.create_subscription(
            AwapiVehicleStatus, "/awapi/vehicle/get/status", self.callback, sub_qos
        )


    # 処理用callback関数
    def callback(self, msg):
        print(msg.data)


def main():
    # RCLの初期化を実行
    rclpy.init()

    # Listenerクラスのコンスタンス化
    node = Listener()

    # ループに入りnode内の処理を実行させる
    rclpy.spin(node)

    # nodeを破壊
    node.destroy_node()

    # RCLをシャットダウン
    rclpy.shutdown()

if __name__ == "__main__":
    main()
```

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Code follows [coding guidelines][coding-guidelines]
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s).
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
