### PR TITLE
feat: add option to ignore set engage request when the status is emergency

### DIFF
--- a/autoware_iv_internal_api_adaptor/src/operator.cpp
+++ b/autoware_iv_internal_api_adaptor/src/operator.cpp
@@ -25,7 +25,7 @@ Operator::Operator(const rclcpp::NodeOptions & options) : Node("external_api_ope
   using std::placeholders::_2;
   tier4_api_utils::ServiceProxyNodeInterface proxy(this);
 
-  send_engage_in_emergency_ = declare_parameter("send_engage_in_emergency", true);
+  send_engage_in_emergency_ = declare_parameter("send_engage_in_emergency", false);
 
   group_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   srv_set_operator_ = proxy.create_service<tier4_external_api_msgs::srv::SetOperator>(

--- a/autoware_iv_internal_api_adaptor/src/operator.cpp
+++ b/autoware_iv_internal_api_adaptor/src/operator.cpp
@@ -25,7 +25,7 @@ Operator::Operator(const rclcpp::NodeOptions & options) : Node("external_api_ope
   using std::placeholders::_2;
   tier4_api_utils::ServiceProxyNodeInterface proxy(this);
 
-  send_engage_in_emergency_ = declare_parameter("send_engage_in_emergency", false);
+  send_engage_in_emergency_ = declare_parameter("send_engage_in_emergency", true);
 
   group_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   srv_set_operator_ = proxy.create_service<tier4_external_api_msgs::srv::SetOperator>(

--- a/autoware_iv_internal_api_adaptor/src/operator.cpp
+++ b/autoware_iv_internal_api_adaptor/src/operator.cpp
@@ -75,7 +75,7 @@ void Operator::setOperator(
       return;
 
     case tier4_external_api_msgs::msg::Operator::AUTONOMOUS:
-      if (!send_engage_in_emergency_ && emergency_status_->emergency) {
+      if (!send_engage_in_emergency_ && emergency_status_ && emergency_status_->emergency) {
         // do not send engage command when the status is emergency
         response->status =
           tier4_api_utils::response_error("ignored request because the status is emergency.");

--- a/autoware_iv_internal_api_adaptor/src/operator.hpp
+++ b/autoware_iv_internal_api_adaptor/src/operator.hpp
@@ -23,6 +23,7 @@
 #include <tier4_control_msgs/msg/external_command_selector_mode.hpp>
 #include <tier4_control_msgs/msg/gate_mode.hpp>
 #include <tier4_control_msgs/srv/external_command_select.hpp>
+#include <tier4_external_api_msgs/msg/emergency.hpp>
 #include <tier4_external_api_msgs/msg/observer.hpp>
 #include <tier4_external_api_msgs/msg/operator.hpp>
 #include <tier4_external_api_msgs/srv/set_observer.hpp>
@@ -63,6 +64,7 @@ private:
   rclcpp::Subscription<ExternalCommandSelectorMode>::SharedPtr sub_external_select_;
   rclcpp::Subscription<GateMode>::SharedPtr sub_gate_mode_;
   rclcpp::Subscription<VehicleControlMode>::SharedPtr sub_vehicle_control_mode_;
+  rclcpp::Subscription<tier4_external_api_msgs::msg::Emergency>::SharedPtr sub_emergency_;
   rclcpp::TimerBase::SharedPtr timer_;
 
   // ros callback
@@ -77,12 +79,15 @@ private:
   void onGateMode(const tier4_control_msgs::msg::GateMode::ConstSharedPtr message);
   void onVehicleControlMode(
     const autoware_auto_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr message);
+  void onEmergencyStatus(const tier4_external_api_msgs::msg::Emergency::ConstSharedPtr msg);
   void onTimer();
 
   // class field
   tier4_control_msgs::msg::ExternalCommandSelectorMode::ConstSharedPtr external_select_;
   tier4_control_msgs::msg::GateMode::ConstSharedPtr gate_mode_;
   autoware_auto_vehicle_msgs::msg::ControlModeReport::ConstSharedPtr vehicle_control_mode_;
+  tier4_external_api_msgs::msg::Emergency::ConstSharedPtr emergency_status_;
+  bool send_engage_in_emergency_;
 
   // class method
   void publishOperator();


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- New Feature

## Related Links
https://github.com/tier4/autoware_launch/pull/445

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description
In the current implementation, when a engage request is sent, Autoware will be engaged even if the autoware is in an emergency state.
I added the option to ignore the engage request when the autoware state is an emergency state

<!-- Describe what this PR changes. -->

## Review Procedure
1. run the planning simulator, and set the vehicle position and goal.

2. set autoware to emergency state
$ros2 service call /api/autoware/set/emergency tier4_external_api_msgs/srv/SetEmergency "{emergency: true}"

3. check that the emergency state is true
$ros2 topic echo /api/autoware/get/emergency

4. call SetOperatorService, and check that the message: `'ignored request because the status is emergency.'` returns.
$ros2 service call /api/autoware/set/operator tier4_external_api_msgs/srv/SetOperator "{mode: {mode: 2}}"

5. check that the engage state remains false
ros2 topic echo /api/autoware/get/engage

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s).
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
