### PR TITLE
fix: change initial pose timeout

### DIFF
--- a/autoware_iv_external_api_adaptor/src/initial_pose.cpp
+++ b/autoware_iv_external_api_adaptor/src/initial_pose.cpp
@@ -19,6 +19,8 @@
 namespace external_api
 {
 
+constexpr auto initial_pose_timeout = std::chrono::seconds(300);
+
 InitialPose::InitialPose(const rclcpp::NodeOptions & options)
 : Node("external_api_initial_pose", options)
 {
@@ -44,7 +46,7 @@ void InitialPose::setInitializePose(
   const tier4_external_api_msgs::srv::InitializePose::Request::SharedPtr request,
   const tier4_external_api_msgs::srv::InitializePose::Response::SharedPtr response)
 {
-  const auto [status, resp] = cli_set_initialize_pose_->call(request);
+  const auto [status, resp] = cli_set_initialize_pose_->call(request, initial_pose_timeout);
   if (!tier4_api_utils::is_success(status)) {
     response->status = status;
     return;
@@ -56,7 +58,7 @@ void InitialPose::setInitializePoseAuto(
   const tier4_external_api_msgs::srv::InitializePoseAuto::Request::SharedPtr request,
   const tier4_external_api_msgs::srv::InitializePoseAuto::Response::SharedPtr response)
 {
-  const auto [status, resp] = cli_set_initialize_pose_auto_->call(request);
+  const auto [status, resp] = cli_set_initialize_pose_auto_->call(request, initial_pose_timeout);
   if (!tier4_api_utils::is_success(status)) {
     response->status = status;
     return;

--- a/autoware_iv_internal_api_adaptor/src/initial_pose.cpp
+++ b/autoware_iv_internal_api_adaptor/src/initial_pose.cpp
@@ -18,6 +18,9 @@
 
 namespace internal_api
 {
+
+constexpr auto initial_pose_timeout = std::chrono::seconds(300);
+
 InitialPose::InitialPose(const rclcpp::NodeOptions & options)
 : Node("internal_api_initial_pose", options)
 {
@@ -72,7 +75,7 @@ void InitialPose::setInitializePose(
   if (init_localization_pose_) {
     const auto req = std::make_shared<PoseWithCovarianceStampedSrv::Request>();
     req->pose_with_covariance = request->pose;
-    const auto [status, resp] = cli_set_initialize_pose_->call(req);
+    const auto [status, resp] = cli_set_initialize_pose_->call(req, initial_pose_timeout);
     if (!tier4_api_utils::is_success(status)) {
       response->status = status;
       return;
@@ -92,7 +95,7 @@ void InitialPose::setInitializePoseAuto(
   response->status = tier4_api_utils::response_ignored("No processing.");
 
   if (init_localization_pose_) {
-    const auto [status, resp] = cli_set_initialize_pose_auto_->call(request);
+    const auto [status, resp] = cli_set_initialize_pose_auto_->call(request, initial_pose_timeout);
     if (!tier4_api_utils::is_success(status)) {
       response->status = status;
       return;


### PR DESCRIPTION
Signed-off-by: Takagi, Isamu <isamu.takagi@tier4.jp>

## PR Type

- Bug Fix

## Related Links

TIER IV tracking code: EVT4-2050

## Description

Change initial pose timeout. The default timeout was not enough as pose initialization takes a long time.

## Review Procedure

Call initialize pose service at environment that takes time and check the result is not timeout. For example, change `initial_estimate_particles_num` in `ndt_scan_matcher.param.yaml` to a larger value.

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Code follows [coding guidelines][coding-guidelines]
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s).
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
