### PR TITLE
fix: rename use_external_emergency_stop to check_external_emergency_heartbeat

### DIFF
--- a/awapi_awiv_adapter/launch/awapi_awiv_adapter.launch.xml
+++ b/awapi_awiv_adapter/launch/awapi_awiv_adapter.launch.xml
@@ -61,7 +61,7 @@
   <arg name="output_overwrite_traffic_signals" default="/external/traffic_light_recognition/traffic_signals"/>
 
   <arg name="node_emergency_stop" default="/control/vehicle_cmd_gate"/>
-  <arg name="param_emergency_stop" default="use_external_emergency_stop"/>
+  <arg name="param_emergency_stop" default="check_external_emergency_heartbeat"/>
   <arg name="node_max_velocity" default="/planning/scenario_planning/motion_velocity_smoother"/>
   <arg name="param_max_velocity" default="max_velocity"/>
 

--- a/awapi_awiv_adapter/src/awapi_awiv_adapter_core.cpp
+++ b/awapi_awiv_adapter/src/awapi_awiv_adapter_core.cpp
@@ -138,7 +138,7 @@ AutowareIvAdapter::AutowareIvAdapter()
 void AutowareIvAdapter::emergencyParamCheck(const bool emergency_stop_param)
 {
   if (!emergency_stop_param) {
-    RCLCPP_WARN_STREAM(get_logger(), "parameter[use_external_emergency_stop] is false.");
+    RCLCPP_WARN_STREAM(get_logger(), "parameter[check_external_emergency_heartbeat] is false.");
     RCLCPP_WARN_STREAM(get_logger(), "autoware/put/emergency is not valid");
   }
 }


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Improvement

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->
https://github.com/autowarefoundation/autoware.universe/pull/2455
## Description

<!-- Describe what this PR changes. -->

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Code follows [coding guidelines][coding-guidelines]
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s).
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
