### PR TITLE
fix(stop_reason_aggregator): fix threshold for closest index

### DIFF
--- a/awapi_awiv_adapter/include/awapi_awiv_adapter/awapi_autoware_util.hpp
+++ b/awapi_awiv_adapter/include/awapi_awiv_adapter/awapi_autoware_util.hpp
@@ -121,7 +121,7 @@ namespace planning_util
 {
 bool calcClosestIndex(
   const autoware_auto_planning_msgs::msg::Trajectory & traj, const geometry_msgs::msg::Pose & pose,
-  size_t & output_closest_idx, const double dist_thr = 10.0, const double angle_thr = M_PI / 2.0);
+  size_t & output_closest_idx, const double dist_thr = 10.0, const double angle_thr = M_PI_4);
 
 inline geometry_msgs::msg::Pose getPose(
   const autoware_auto_planning_msgs::msg::Trajectory & traj, const int idx)


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Bug Fix

## Related Links

https://tier4.atlassian.net/browse/T4PB-27577

## Description

when angle threshold is M_PI / 2.0, dist_to_stop_pose is 0 of obstacle stop and detection area on `/awapi/autoware/get/status` in following situation.
![image](https://user-images.githubusercontent.com/9547070/231961646-28bcfc40-b154-4fb9-8dbd-13236bffd494.png)

I fix it to M_PI_4 (45deg) because this value is often used in planning module in autoware.universe.
e.g. https://github.com/tier4/autoware.universe/blob/beta/v0.3.14/planning/behavior_velocity_planner/include/utilization/util.hpp#L163-L165


## Review Procedure

I confirmed not showing stop reason for obstacle stop and detection area on `/awapi/autoware/get/status` in planning_simulator.
![image](https://user-images.githubusercontent.com/9547070/231963941-7794bd53-3e32-4b60-8b81-80118f2e7980.png)



## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s).
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
