### PR TITLE
fix: change the output of ControlMode to autoware_auto_msgs

### DIFF
--- a/autoware_iv_internal_api_adaptor/package.xml
+++ b/autoware_iv_internal_api_adaptor/package.xml
@@ -11,6 +11,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
+  <depend>autoware_auto_vehicle_msgs</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_system_msgs</depend>

--- a/autoware_iv_internal_api_adaptor/src/iv_msgs.cpp
+++ b/autoware_iv_internal_api_adaptor/src/iv_msgs.cpp
@@ -30,7 +30,7 @@ IVMsgs::IVMsgs(const rclcpp::NodeOptions & options) : Node("external_api_iv_msgs
 
   pub_control_mode_ =
     create_publisher<ControlModeAuto>("/api/iv_msgs/vehicle/status/control_mode", rclcpp::QoS(1));
-  sub_control_mode_ = create_subscription<ControlModeAuto>(
+  sub_control_mode_ = create_subscription<ControlMode>(
     "/vehicle/status/control_mode", rclcpp::QoS(1), std::bind(&IVMsgs::onControlMode, this, _1));
 
   pub_trajectory_ = create_publisher<TrajectoryIV>(
@@ -62,9 +62,12 @@ void IVMsgs::onEmergency(const EmergencyStateAuto::ConstSharedPtr message)
   is_emergency_ = message->state != EmergencyStateAuto::NORMAL;
 }
 
-void IVMsgs::onControlMode(const ControlModeAuto::ConstSharedPtr message)
+void IVMsgs::onControlMode(const ControlMode::ConstSharedPtr message)
 {
-  pub_control_mode_->publish(*message);
+  ControlModeAuto control_mode_auto;
+  control_mode_auto.stamp = message->stamp;
+  control_mode_auto.mode = message->mode;
+  pub_control_mode_->publish(control_mode_auto);
 }
 
 void IVMsgs::onTrajectory(const TrajectoryAuto::ConstSharedPtr message)

--- a/autoware_iv_internal_api_adaptor/src/iv_msgs.hpp
+++ b/autoware_iv_internal_api_adaptor/src/iv_msgs.hpp
@@ -18,6 +18,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_adapi_v1_msgs/msg/mrm_state.hpp>
+#include <autoware_auto_vehicle_msgs/msg/control_mode_report.hpp>
 #include <autoware_perception_msgs/msg/tracked_objects.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <autoware_system_msgs/msg/autoware_state.hpp>
@@ -42,7 +43,8 @@ private:
   rclcpp::Publisher<AutowareStateIV>::SharedPtr pub_state_;
 
   using ControlModeAuto = autoware_vehicle_msgs::msg::ControlModeReport;
-  rclcpp::Subscription<ControlModeAuto>::SharedPtr sub_control_mode_;
+  using ControlMode = autoware_auto_vehicle_msgs::msg::ControlModeReport;
+  rclcpp::Subscription<ControlMode>::SharedPtr sub_control_mode_;
   rclcpp::Publisher<ControlModeAuto>::SharedPtr pub_control_mode_;
 
   using TrajectoryAuto = autoware_planning_msgs::msg::Trajectory;
@@ -57,7 +59,7 @@ private:
 
   void onState(const AutowareStateAuto::ConstSharedPtr message);
   void onEmergency(const EmergencyStateAuto::ConstSharedPtr message);
-  void onControlMode(const ControlModeAuto::ConstSharedPtr message);
+  void onControlMode(const ControlMode::ConstSharedPtr message);
   void onTrajectory(const TrajectoryAuto::ConstSharedPtr message);
   void onTrackedObjects(const TrackedObjectsAuto::ConstSharedPtr message);
 


### PR DESCRIPTION
## PR Type

- Bug Fix

## Related Links

https://github.com/tier4/tier4_ad_api_adaptor/pull/115

## Description

The PR modifies the output for `/api/iv_msgs/vehicle/status/control_mode` to autoware_auto_vehicle_msgs.

## Review Procedure

Launch the adapter
`ros2 launch autoware_iv_internal_api_adaptor internal_api_adaptor.launch.py`

check that the output topic is in autoware_auto_msgs
`ros2 topic info /api/iv_msgs/vehicle/status/control_mode -v`

```
Type: autoware_auto_vehicle_msgs/msg/ControlModeReport

Publisher count: 1

Node name: iv_msgs
Node namespace: /internal
Topic type: autoware_auto_vehicle_msgs/msg/ControlModeReport
Endpoint type: PUBLISHER
GID: 01.10.1f.18.54.3e.3a.f7.fc.07.67.c8.00.00.20.03.00.00.00.00.00.00.00.00
QoS profile:
  Reliability: RELIABLE
  History (Depth): KEEP_LAST (1)
  Durability: VOLATILE
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite

Subscription count: 0
```

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s).
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
