### PR TITLE
feat: rename autoware_component_interface_specs to autoware_component_interface_specs_universe

### DIFF
--- a/autoware_iv_external_api_adaptor/package.xml
+++ b/autoware_iv_external_api_adaptor/package.xml
@@ -11,7 +11,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_specs</depend>
-  <depend>autoware_universe_component_interface_specs</depend>
+  <depend>autoware_component_interface_specs_universe</depend>
   <depend>autoware_component_interface_utils</depend>
   <depend>autoware_control_msgs</depend>
   <depend>autoware_external_api_msgs</depend>

--- a/autoware_iv_external_api_adaptor/package.xml
+++ b/autoware_iv_external_api_adaptor/package.xml
@@ -11,7 +11,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_specs</depend>
-  <depend>autoware_component_interface_specs</depend>
+  <depend>autoware_universe_component_interface_specs</depend>
   <depend>autoware_component_interface_utils</depend>
   <depend>autoware_control_msgs</depend>
   <depend>autoware_external_api_msgs</depend>

--- a/autoware_iv_external_api_adaptor/src/initial_pose.cpp
+++ b/autoware_iv_external_api_adaptor/src/initial_pose.cpp
@@ -61,9 +61,9 @@ void InitialPose::setInitializePose(
   const tier4_external_api_msgs::srv::InitializePose::Response::SharedPtr response)
 {
   const auto req = std::make_shared<
-    autoware::component_interface_specs::localization::Initialize::Service::Request>();
+    autoware::universe_component_interface_specs::localization::Initialize::Service::Request>();
   req->method =
-    autoware::component_interface_specs::localization::Initialize::Service::Request::AUTO;
+    autoware::universe_component_interface_specs::localization::Initialize::Service::Request::AUTO;
   req->pose_with_covariance.push_back(request->pose);
   req->pose_with_covariance.back().pose.covariance = particle_covariance;
 
@@ -80,9 +80,9 @@ void InitialPose::setInitializePoseAuto(
   const tier4_external_api_msgs::srv::InitializePoseAuto::Response::SharedPtr response)
 {
   const auto req = std::make_shared<
-    autoware::component_interface_specs::localization::Initialize::Service::Request>();
+    autoware::universe_component_interface_specs::localization::Initialize::Service::Request>();
   req->method =
-    autoware::component_interface_specs::localization::Initialize::Service::Request::AUTO;
+    autoware::universe_component_interface_specs::localization::Initialize::Service::Request::AUTO;
 
   try {
     const auto res = cli_localization_initialize_->call(req, initial_pose_timeout);

--- a/autoware_iv_external_api_adaptor/src/initial_pose.cpp
+++ b/autoware_iv_external_api_adaptor/src/initial_pose.cpp
@@ -61,9 +61,9 @@ void InitialPose::setInitializePose(
   const tier4_external_api_msgs::srv::InitializePose::Response::SharedPtr response)
 {
   const auto req = std::make_shared<
-    autoware::universe_component_interface_specs::localization::Initialize::Service::Request>();
+    autoware::component_interface_specs_universe::localization::Initialize::Service::Request>();
   req->method =
-    autoware::universe_component_interface_specs::localization::Initialize::Service::Request::AUTO;
+    autoware::component_interface_specs_universe::localization::Initialize::Service::Request::AUTO;
   req->pose_with_covariance.push_back(request->pose);
   req->pose_with_covariance.back().pose.covariance = particle_covariance;
 
@@ -80,9 +80,9 @@ void InitialPose::setInitializePoseAuto(
   const tier4_external_api_msgs::srv::InitializePoseAuto::Response::SharedPtr response)
 {
   const auto req = std::make_shared<
-    autoware::universe_component_interface_specs::localization::Initialize::Service::Request>();
+    autoware::component_interface_specs_universe::localization::Initialize::Service::Request>();
   req->method =
-    autoware::universe_component_interface_specs::localization::Initialize::Service::Request::AUTO;
+    autoware::component_interface_specs_universe::localization::Initialize::Service::Request::AUTO;
 
   try {
     const auto res = cli_localization_initialize_->call(req, initial_pose_timeout);

--- a/autoware_iv_external_api_adaptor/src/initial_pose.hpp
+++ b/autoware_iv_external_api_adaptor/src/initial_pose.hpp
@@ -15,7 +15,7 @@
 #ifndef INITIAL_POSE_HPP_
 #define INITIAL_POSE_HPP_
 
-#include <autoware/component_interface_specs/localization.hpp>
+#include <autoware/universe_component_interface_specs/localization.hpp>
 #include <autoware/component_interface_utils/rclcpp.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <tier4_api_utils/tier4_api_utils.hpp>
@@ -40,7 +40,7 @@ private:
   tier4_api_utils::Service<InitializePose>::SharedPtr srv_set_initialize_pose_;
   tier4_api_utils::Service<InitializePoseAuto>::SharedPtr srv_set_initialize_pose_auto_;
   autoware::component_interface_utils::Client<
-    autoware::component_interface_specs::localization::Initialize>::SharedPtr
+    autoware::universe_component_interface_specs::localization::Initialize>::SharedPtr
     cli_localization_initialize_;
 
   // ros callback

--- a/autoware_iv_external_api_adaptor/src/initial_pose.hpp
+++ b/autoware_iv_external_api_adaptor/src/initial_pose.hpp
@@ -15,7 +15,7 @@
 #ifndef INITIAL_POSE_HPP_
 #define INITIAL_POSE_HPP_
 
-#include <autoware/universe_component_interface_specs/localization.hpp>
+#include <autoware/component_interface_specs_universe/localization.hpp>
 #include <autoware/component_interface_utils/rclcpp.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <tier4_api_utils/tier4_api_utils.hpp>
@@ -40,7 +40,7 @@ private:
   tier4_api_utils::Service<InitializePose>::SharedPtr srv_set_initialize_pose_;
   tier4_api_utils::Service<InitializePoseAuto>::SharedPtr srv_set_initialize_pose_auto_;
   autoware::component_interface_utils::Client<
-    autoware::universe_component_interface_specs::localization::Initialize>::SharedPtr
+    autoware::component_interface_specs_universe::localization::Initialize>::SharedPtr
     cli_localization_initialize_;
 
   // ros callback


### PR DESCRIPTION
## PR Type

- Improvement

## Related Links

https://github.com/autowarefoundation/autoware.universe/pull/9753

## Description
This PR fixes the package name for autoware_compoent_interface_specs.

<!-- Describe what this PR changes. -->

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Code follows [coding guidelines][coding-guidelines]
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s).
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
