### PR TITLE
fix: replace debug_msgs in localization_score

### DIFF
--- a/autoware_iv_external_api_adaptor/package.xml
+++ b/autoware_iv_external_api_adaptor/package.xml
@@ -15,6 +15,7 @@
   <depend>autoware_component_interface_utils</depend>
   <depend>autoware_control_msgs</depend>
   <depend>autoware_external_api_msgs</depend>
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_system_msgs</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>nlohmann-json-dev</depend>
@@ -24,7 +25,6 @@
   <depend>tier4_api_msgs</depend>
   <depend>tier4_api_utils</depend>
   <depend>tier4_auto_msgs_converter</depend>
-  <depend>tier4_debug_msgs</depend>
   <depend>tier4_external_api_msgs</depend>
   <depend>tier4_rtc_msgs</depend>
   <depend>tier4_vehicle_msgs</depend>

--- a/autoware_iv_external_api_adaptor/src/localization_score.hpp
+++ b/autoware_iv_external_api_adaptor/src/localization_score.hpp
@@ -26,8 +26,8 @@
 
 namespace external_api
 {
-using geometry_msgs::msg::PoseWithCovarianceStamped;
 using autoware_internal_debug_msgs::msg::Float32Stamped;
+using geometry_msgs::msg::PoseWithCovarianceStamped;
 using tier4_external_api_msgs::msg::LocalizationScoreArray;
 
 class LocalizationScore : public rclcpp::Node

--- a/autoware_iv_external_api_adaptor/src/localization_score.hpp
+++ b/autoware_iv_external_api_adaptor/src/localization_score.hpp
@@ -18,8 +18,8 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include "tier4_external_api_msgs/msg/localization_score_array.hpp"
+#include <autoware_internal_debug_msgs/msg/float32_stamped.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
-#include <tier4_debug_msgs/msg/float32_stamped.hpp>
 
 #include <memory>
 #include <utility>
@@ -27,7 +27,7 @@
 namespace external_api
 {
 using geometry_msgs::msg::PoseWithCovarianceStamped;
-using tier4_debug_msgs::msg::Float32Stamped;
+using autoware_internal_debug_msgs::msg::Float32Stamped;
 using tier4_external_api_msgs::msg::LocalizationScoreArray;
 
 class LocalizationScore : public rclcpp::Node


### PR DESCRIPTION
## PR Type

- Bug Fix

## Related Links

- https://github.com/autowarefoundation/autoware.universe/pull/9861

## Description

In autoware, the messages used for debugging have been changed from `tier4_debug_msgs` to `autoware_internal_debug_msgs`.

This pull request replaces the type of debug_msgs used in `localization_score` with the above changes.

Before
```
[ERROR] [1738547974.209400077] [ROSBAG2_TRANSPORT]: Topic '/localization/pose_estimator/nearest_voxel_transformation_likelihood' has more than one type associated. Only topics with one type are supported
```

```
$ ros2 topic info -v /localization/pose_estimator/nearest_voxel_transformation_likelihood
Type: ['autoware_internal_debug_msgs/msg/Float32Stamped', 'tier4_debug_msgs/msg/Float32Stamped']
Publisher count: 1
Node name: ndt_scan_matcher
Node namespace: /localization/pose_estimator
Topic type: autoware_internal_debug_msgs/msg/Float32Stamped
Endpoint type: PUBLISHER
GID: 01.10.b9.e1.9a.9d.58.66.fe.68.ca.4f.00.00.27.03.00.00.00.00.00.00.00.00
QoS profile:
  Reliability: RELIABLE
  History (Depth): KEEP_LAST (10)
  Durability: VOLATILE
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite

Subscription count: 2

Node name: localization_score
Node namespace: /autoware_api/external
Topic type: tier4_debug_msgs/msg/Float32Stamped
Endpoint type: SUBSCRIPTION
GID: 01.10.06.49.8b.01.19.e4.98.05.c9.d3.00.00.c8.04.00.00.00.00.00.00.00.00
QoS profile:
  Reliability: RELIABLE
  History (Depth): KEEP_LAST (1)
  Durability: VOLATILE
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite

Node name: rosbag2_recorder
Node namespace: /
Topic type: autoware_internal_debug_msgs/msg/Float32Stamped
Endpoint type: SUBSCRIPTION
GID: 01.10.26.81.ed.53.74.03.01.df.9a.98.00.00.3e.04.00.00.00.00.00.00.00.00
QoS profile:
  Reliability: RELIABLE
  History (Depth): KEEP_LAST (10)
  Durability: VOLATILE
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite

```

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Code follows [coding guidelines][coding-guidelines]
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s).
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
