### PR TITLE
ci: use universe-devel container for build CIs

### DIFF
--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -55,6 +55,7 @@ jobs:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
           build-depends-repos: ${{ matrix.build-depends-repos }}
+          underlay-workspace: /opt/autoware
 
       - name: Test
         id: test
@@ -64,6 +65,7 @@ jobs:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
           build-depends-repos: ${{ matrix.build-depends-repos }}
+          underlay-workspace: /opt/autoware
 
       - name: Upload coverage to CodeCov
         if: ${{ steps.test.outputs.coverage-report-files != '' }}

--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -26,7 +26,7 @@ jobs:
           - humble
         include:
           - rosdistro: humble
-            container: ros:humble
+            container: ghcr.io/autowarefoundation/autoware:universe-devel
             build-depends-repos: build_depends.repos
     steps:
       - name: Set PR fetch depth

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -18,7 +18,7 @@ jobs:
           - humble
         include:
           - rosdistro: humble
-            container: ros:humble
+            container: ghcr.io/autowarefoundation/autoware:universe-devel
             build-depends-repos: build_depends.repos
     steps:
       - name: Check out repository

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -43,6 +43,7 @@ jobs:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
           build-depends-repos: ${{ matrix.build-depends-repos }}
+          underlay-workspace: /opt/autoware
 
       - name: Test
         if: ${{ steps.get-self-packages.outputs.self-packages != '' }}
@@ -52,6 +53,7 @@ jobs:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
           build-depends-repos: ${{ matrix.build-depends-repos }}
+          underlay-workspace: /opt/autoware
 
       - name: Upload coverage to CodeCov
         if: ${{ steps.test.outputs.coverage-report-files != '' }}

--- a/build_depends.repos
+++ b/build_depends.repos
@@ -15,7 +15,3 @@ repositories:
     type: git
     url: https://github.com/tier4/tier4_autoware_msgs.git
     version: tier4/universe
-  universe/universe:
-    type: git
-    url: https://github.com/autowarefoundation/autoware.universe
-    version: main


### PR DESCRIPTION
## Description
This updates the build test CI to use autoware:universe-devel containers to skip the build of autoware_universe to speed up CI, and also fixes the issue with version difference between autoware_universe and it's dependent repositories.

## How this was tested

~Test using build-and-test action
https://github.com/tier4/tier4_ad_api_adaptor/actions/runs/14377614593
note: the build is currently failing due to a bug in colcon-test action. Waiting for this PR to be merged: https://github.com/autowarefoundation/autoware-github-actions/pull/342~

new test is running in: https://github.com/tier4/tier4_ad_api_adaptor/actions/runs/14382544061/job/40329750955