### PR TITLE
feat(tier4_autoware_api_extension): add traffic light api

### DIFF
--- a/tier4_autoware_api_extension/CMakeLists.txt
+++ b/tier4_autoware_api_extension/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.14)
+project(tier4_autoware_api_extension)
+
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/traffic_light.cpp
+)
+
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "tier4_autoware_api_extension::TrafficLight"
+  EXECUTABLE traffic_light_node
+)
+
+ament_auto_package(INSTALL_TO_SHARE launch)

--- a/tier4_autoware_api_extension/README.md
+++ b/tier4_autoware_api_extension/README.md
@@ -1,0 +1,4 @@
+# tier4_autoware_api_extension
+
+This package provides API that specialized for use cases in TIER IV.
+[See here for the TIER IV API specification.](https://tier4.github.io/autoware-documentation/tier4-main/design/autoware-interfaces/prototyping/)

--- a/tier4_autoware_api_extension/launch/tier4_autoware_api_extension.launch.xml
+++ b/tier4_autoware_api_extension/launch/tier4_autoware_api_extension.launch.xml
@@ -1,0 +1,6 @@
+<launch>
+  <group>
+    <push-ros-namespace namespace="tier4_api"/>
+    <node pkg="tier4_autoware_api_extension" exec="traffic_light_node"/>
+  </group>
+</launch>

--- a/tier4_autoware_api_extension/package.xml
+++ b/tier4_autoware_api_extension/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>tier4_autoware_api_extension</name>
+  <version>0.43.0</version>
+  <description>The tier4_autoware_api_extension package</description>
+  <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
+
+  <depend>autoware_perception_msgs</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <depend>tier4_external_api_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>autoware_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/tier4_autoware_api_extension/src/traffic_light.cpp
+++ b/tier4_autoware_api_extension/src/traffic_light.cpp
@@ -34,7 +34,7 @@ TrafficLight::TrafficLight(const rclcpp::NodeOptions & options) : Node("traffic_
     std::bind(&TrafficLight::on_message, this, std::placeholders::_1));
 
   pub_traffic_light_group_ =
-    create_publisher<ExternalMessage>("/api/external/nearest_traffic_light_group", 1);
+    create_publisher<ExternalMessage>("/api/external/get/nearest_traffic_light_group", 1);
 }
 
 void TrafficLight::on_message(const InternalMessage & internal)

--- a/tier4_autoware_api_extension/src/traffic_light.cpp
+++ b/tier4_autoware_api_extension/src/traffic_light.cpp
@@ -1,0 +1,53 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "traffic_light.hpp"
+
+namespace tier4_autoware_api_extension
+{
+
+auto convert(const autoware_perception_msgs::msg::TrafficLightElement & internal)
+{
+  tier4_external_api_msgs::msg::TrafficLightElement external;
+  external.color = internal.color;
+  external.shape = internal.shape;
+  external.status = internal.status;
+  external.confidence = internal.confidence;
+  return external;
+}
+
+TrafficLight::TrafficLight(const rclcpp::NodeOptions & options) : Node("traffic_light", options)
+{
+  sub_traffic_light_group_ = create_subscription<InternalMessage>(
+    "/planning/scenario_planning/lane_driving/behavior_planning/debug/traffic_signal", 1,
+    std::bind(&TrafficLight::on_message, this, std::placeholders::_1));
+
+  pub_traffic_light_group_ =
+    create_publisher<ExternalMessage>("/api/external/nearest_traffic_light_group", 1);
+}
+
+void TrafficLight::on_message(const InternalMessage & internal)
+{
+  ExternalMessage external;
+  external.traffic_light_group_id = internal.traffic_light_group_id;
+  for (const auto & element : internal.elements) {
+    external.elements.push_back(convert(element));
+  }
+  pub_traffic_light_group_->publish(external);
+}
+
+}  // namespace tier4_autoware_api_extension
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(tier4_autoware_api_extension::TrafficLight)

--- a/tier4_autoware_api_extension/src/traffic_light.hpp
+++ b/tier4_autoware_api_extension/src/traffic_light.hpp
@@ -1,0 +1,42 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TRAFFIC_LIGHT_HPP_
+#define TRAFFIC_LIGHT_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_perception_msgs/msg/traffic_light_group.hpp>
+#include <tier4_external_api_msgs/msg/traffic_light_group.hpp>
+
+namespace tier4_autoware_api_extension
+{
+
+using ExternalMessage = tier4_external_api_msgs::msg::TrafficLightGroup;
+using InternalMessage = autoware_perception_msgs::msg::TrafficLightGroup;
+
+class TrafficLight : public rclcpp::Node
+{
+public:
+  explicit TrafficLight(const rclcpp::NodeOptions & options);
+
+private:
+  void on_message(const InternalMessage & internal);
+  rclcpp::Subscription<InternalMessage>::SharedPtr sub_traffic_light_group_;
+  rclcpp::Publisher<ExternalMessage>::SharedPtr pub_traffic_light_group_;
+};
+
+}  // namespace tier4_autoware_api_extension
+
+#endif  // TRAFFIC_LIGHT_HPP_


### PR DESCRIPTION
Add traffic light API. See https://github.com/tier4/tier4_ad_api_adaptor/blob/8d245eee44eabf9f6dd6a2b701c671b60b09384b/doc/api/external/get/nearest_traffic_light_group.md for details.