### PR TITLE
feat!: replace tier4_system_msgs with autoware_system_msgs

### DIFF
--- a/autoware_iv_internal_api_adaptor/src/operator.cpp
+++ b/autoware_iv_internal_api_adaptor/src/operator.cpp
@@ -37,8 +37,8 @@ Operator::Operator(const rclcpp::NodeOptions & options) : Node("external_api_ope
 
   cli_external_select_ = proxy.create_client<tier4_control_msgs::srv::ExternalCommandSelect>(
     "/control/external_cmd_selector/select_external_command");
-  cli_autoware_control_ = proxy.create_client<ChangeAutowareControl>(
-    "/system/operation_mode/change_autoware_control");
+  cli_autoware_control_ =
+    proxy.create_client<ChangeAutowareControl>("/system/operation_mode/change_autoware_control");
   pub_gate_mode_ =
     create_publisher<tier4_control_msgs::msg::GateMode>("/control/gate_mode_cmd", rclcpp::QoS(1));
 

--- a/autoware_iv_internal_api_adaptor/src/operator.cpp
+++ b/autoware_iv_internal_api_adaptor/src/operator.cpp
@@ -37,7 +37,7 @@ Operator::Operator(const rclcpp::NodeOptions & options) : Node("external_api_ope
 
   cli_external_select_ = proxy.create_client<tier4_control_msgs::srv::ExternalCommandSelect>(
     "/control/external_cmd_selector/select_external_command");
-  cli_autoware_control_ = proxy.create_client<tier4_system_msgs::srv::ChangeAutowareControl>(
+  cli_autoware_control_ = proxy.create_client<ChangeAutowareControl>(
     "/system/operation_mode/change_autoware_control");
   pub_gate_mode_ =
     create_publisher<tier4_control_msgs::msg::GateMode>("/control/gate_mode_cmd", rclcpp::QoS(1));

--- a/autoware_iv_internal_api_adaptor/src/operator.hpp
+++ b/autoware_iv_internal_api_adaptor/src/operator.hpp
@@ -27,7 +27,7 @@
 #include <tier4_external_api_msgs/msg/operator.hpp>
 #include <tier4_external_api_msgs/srv/set_observer.hpp>
 #include <tier4_external_api_msgs/srv/set_operator.hpp>
-#include <tier4_system_msgs/srv/change_autoware_control.hpp>
+#include <autoware_system_msgs/srv/change_autoware_control.hpp>
 
 namespace internal_api
 {
@@ -45,7 +45,7 @@ private:
   using ExternalCommandSelectorMode = tier4_control_msgs::msg::ExternalCommandSelectorMode;
   using GateMode = tier4_control_msgs::msg::GateMode;
   using ControlModeReport = autoware_vehicle_msgs::msg::ControlModeReport;
-  using ChangeAutowareControl = tier4_system_msgs::srv::ChangeAutowareControl;
+  using ChangeAutowareControl = autoware_system_msgs::srv::ChangeAutowareControl;
   using ResponseStatus = tier4_external_api_msgs::msg::ResponseStatus;
 
   // ros interface

--- a/autoware_iv_internal_api_adaptor/src/operator.hpp
+++ b/autoware_iv_internal_api_adaptor/src/operator.hpp
@@ -18,6 +18,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <tier4_api_utils/tier4_api_utils.hpp>
 
+#include <autoware_system_msgs/srv/change_autoware_control.hpp>
 #include <autoware_vehicle_msgs/msg/control_mode_report.hpp>
 #include <tier4_control_msgs/msg/external_command_selector_mode.hpp>
 #include <tier4_control_msgs/msg/gate_mode.hpp>
@@ -27,7 +28,6 @@
 #include <tier4_external_api_msgs/msg/operator.hpp>
 #include <tier4_external_api_msgs/srv/set_observer.hpp>
 #include <tier4_external_api_msgs/srv/set_operator.hpp>
-#include <autoware_system_msgs/srv/change_autoware_control.hpp>
 
 namespace internal_api
 {


### PR DESCRIPTION
## Description
This replaces tier4_service_msgs services with autoware_service_msgs.
These services are called from AD API modules and should be treated as component interface.

This must be merged with https://github.com/autowarefoundation/autoware_universe/pull/10842
## Related links
- https://github.com/autowarefoundation/autoware_core/issues/541
- https://github.com/autowarefoundation/autoware_universe/pull/10842