### PR TITLE
fix: api version v0.4.1

### DIFF
--- a/autoware_iv_external_api_adaptor/src/version.cpp
+++ b/autoware_iv_external_api_adaptor/src/version.cpp
@@ -33,7 +33,7 @@ void Version::getVersion(
   const autoware_external_api_msgs::srv::GetVersion::Request::SharedPtr,
   const autoware_external_api_msgs::srv::GetVersion::Response::SharedPtr response)
 {
-  response->version = "0.5.0";
+  response->version = "0.4.1";
   response->status = tier4_api_utils::response_success();
 }
 


### PR DESCRIPTION
While the major version is zero, the minor version is changed if it would break compatibility, and the patch version is changed if it would maintain compatibility. The only change we made this time was to add an API, so changing the patch version is correct.