### PR TITLE
feat: engage using operation mode

### DIFF
--- a/autoware_iv_external_api_adaptor/launch/external_api_adaptor.launch.py
+++ b/autoware_iv_external_api_adaptor/launch/external_api_adaptor.launch.py
@@ -35,7 +35,6 @@ def generate_launch_description():
         _create_api_node("diagnostics", "Diagnostics"),
         _create_api_node("door", "Door"),
         _create_api_node("emergency", "Emergency"),
-        _create_api_node("engage", "Engage"),
         _create_api_node("fail_safe_state", "FailSafeState"),
         _create_api_node("initial_pose", "InitialPose"),
         _create_api_node("localization_score", "LocalizationScore"),

--- a/tier4_deprecated_api_adapter/CMakeLists.txt
+++ b/tier4_deprecated_api_adapter/CMakeLists.txt
@@ -5,8 +5,14 @@ find_package(autoware_cmake REQUIRED)
 autoware_package()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/autoware_engage.cpp
   src/manual_control.cpp
   src/manual_status.cpp
+)
+
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "tier4_deprecated_api_adapter::AutowareEngage"
+  EXECUTABLE autoware_engage_node
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}

--- a/tier4_deprecated_api_adapter/CMakeLists.txt
+++ b/tier4_deprecated_api_adapter/CMakeLists.txt
@@ -13,6 +13,7 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 rclcpp_components_register_node(${PROJECT_NAME}
   PLUGIN "tier4_deprecated_api_adapter::AutowareEngage"
   EXECUTABLE autoware_engage_node
+  EXECUTOR MultiThreadedExecutor
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}

--- a/tier4_deprecated_api_adapter/launch/tier4_deprecated_api_adapter.launch.xml
+++ b/tier4_deprecated_api_adapter/launch/tier4_deprecated_api_adapter.launch.xml
@@ -1,6 +1,8 @@
 <launch>
   <group>
     <push-ros-namespace namespace="tier4_api"/>
+    <node pkg="tier4_deprecated_api_adapter" exec="autoware_engage_node" name="engage"/>
+
     <group>
       <push-ros-namespace namespace="manual"/>
       <node pkg="tier4_deprecated_api_adapter" exec="manual_status_node" name="status"/>

--- a/tier4_deprecated_api_adapter/src/autoware_engage.cpp
+++ b/tier4_deprecated_api_adapter/src/autoware_engage.cpp
@@ -1,0 +1,62 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware_engage.hpp"
+
+namespace tier4_deprecated_api_adapter
+{
+
+AutowareEngage::AutowareEngage(const rclcpp::NodeOptions & options)
+: Node("autoware_engage", options)
+{
+  using std::placeholders::_1;
+  using std::placeholders::_2;
+
+  auto_operator_change_ = declare_parameter("auto_operator_change", false);
+  callback_group_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+
+  pub_engage_ = create_publisher<EngageStatus>("/api/external/get/engage", rclcpp::QoS(1));
+  srv_engage_ = create_service<EngageService>(
+    "/api/external/set/engage", std::bind(&AutowareEngage::on_engage, this, _1, _2));
+
+  sub_operation_mode_state_ = create_subscription<OperationModeState>(
+    "/api/operation_mode/state", rclcpp::QoS(1).transient_local(),
+    std::bind(&AutowareEngage::on_state, this, _1));
+  cli_change_stop_mode_ = create_client<ChangeOperationMode>(
+    "/api/operation_mode/change_to_stop", rmw_qos_profile_services_default, callback_group_);
+  cli_change_autonomous_mode_ = create_client<ChangeOperationMode>(
+    "/api/operation_mode/change_to_autonomous", rmw_qos_profile_services_default, callback_group_);
+  cli_change_autoware_control_ = create_client<ChangeOperationMode>(
+    "/api/operation_mode/enable_autoware_control", rmw_qos_profile_services_default,
+    callback_group_);
+
+  state_.mode = OperationModeState::UNKNOWN;
+}
+
+void AutowareEngage::on_state(const OperationModeState & msg)
+{
+  (void)msg;
+}
+
+void AutowareEngage::on_engage(
+  const EngageService::Request::SharedPtr req, EngageService::Response::SharedPtr res)
+{
+  (void)req;
+  (void)res;
+}
+
+}  // namespace tier4_deprecated_api_adapter
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(tier4_deprecated_api_adapter::AutowareEngage)

--- a/tier4_deprecated_api_adapter/src/autoware_engage.cpp
+++ b/tier4_deprecated_api_adapter/src/autoware_engage.cpp
@@ -31,7 +31,7 @@ AutowareEngage::AutowareEngage(const rclcpp::NodeOptions & options)
 
   const auto service_qos = rmw_qos_profile_services_default;
 
-  auto_operator_change_ = declare_parameter("auto_operator_change", false);
+  autoware_control_change_ = declare_parameter("autoware_control_change", false);
   callback_group_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
 
   pub_engage_ = create_publisher<EngageStatus>("/api/external/get/engage", rclcpp::QoS(1));
@@ -83,7 +83,7 @@ void AutowareEngage::on_engage(
     return;
   }
 
-  if (req->engage && auto_operator_change_) {
+  if (autoware_control_change_) {
     const auto client = req->engage ? cli_enable_autoware_control_ : cli_disable_autoware_control_;
     const auto [status, response] = utils::sync_call<ChangeOperationMode>(client, request);
     if (utils::is_error(status)) {

--- a/tier4_deprecated_api_adapter/src/autoware_engage.cpp
+++ b/tier4_deprecated_api_adapter/src/autoware_engage.cpp
@@ -14,6 +14,12 @@
 
 #include "autoware_engage.hpp"
 
+#include "utils/client.hpp"
+#include "utils/response.hpp"
+
+#include <memory>
+#include <string>
+
 namespace tier4_deprecated_api_adapter
 {
 
@@ -37,7 +43,7 @@ AutowareEngage::AutowareEngage(const rclcpp::NodeOptions & options)
     "/api/operation_mode/change_to_stop", rmw_qos_profile_services_default, callback_group_);
   cli_change_autonomous_mode_ = create_client<ChangeOperationMode>(
     "/api/operation_mode/change_to_autonomous", rmw_qos_profile_services_default, callback_group_);
-  cli_change_autoware_control_ = create_client<ChangeOperationMode>(
+  cli_enable_autoware_control_ = create_client<ChangeOperationMode>(
     "/api/operation_mode/enable_autoware_control", rmw_qos_profile_services_default,
     callback_group_);
 
@@ -46,14 +52,51 @@ AutowareEngage::AutowareEngage(const rclcpp::NodeOptions & options)
 
 void AutowareEngage::on_state(const OperationModeState & msg)
 {
-  (void)msg;
+  state_ = msg;
+
+  EngageStatus status;
+  status.stamp = now();
+  status.engage = msg.mode == OperationModeState::AUTONOMOUS;
+  pub_engage_->publish(status);
 }
 
 void AutowareEngage::on_engage(
   const EngageService::Request::SharedPtr req, EngageService::Response::SharedPtr res)
 {
-  (void)req;
-  (void)res;
+  using tier4_external_api_msgs::msg::ResponseStatus;
+  const auto create_response = [](uint16_t code, const std::string & message) {
+    ResponseStatus status;
+    status.code = code;
+    status.message = message;
+    return status;
+  };
+
+  const auto request = std::make_shared<ChangeOperationMode::Request>();
+  const bool is_autonomous_mode = state_.mode == OperationModeState::AUTONOMOUS;
+  const bool is_autoware_control = state_.is_autoware_control_enabled;
+
+  if (req->engage && is_autonomous_mode && is_autoware_control) {
+    res->status = create_response(ResponseStatus::IGNORED, "It is already engaged.");
+    return;
+  }
+
+  if (req->engage && auto_operator_change_) {
+    const auto [status, response] =
+      utils::sync_call<ChangeOperationMode>(cli_enable_autoware_control_, request);
+    if (utils::is_error(status)) {
+      res->status = status;
+      return;
+    }
+  }
+
+  const auto client = req->engage ? cli_change_autonomous_mode_ : cli_change_stop_mode_;
+  const auto [status, response] = utils::sync_call<ChangeOperationMode>(client, request);
+  if (utils::is_error(status)) {
+    res->status = status;
+    return;
+  }
+  res->status.code = response->status.success ? ResponseStatus::SUCCESS : ResponseStatus::ERROR;
+  res->status.message = response->status.message;
 }
 
 }  // namespace tier4_deprecated_api_adapter

--- a/tier4_deprecated_api_adapter/src/autoware_engage.cpp
+++ b/tier4_deprecated_api_adapter/src/autoware_engage.cpp
@@ -29,6 +29,8 @@ AutowareEngage::AutowareEngage(const rclcpp::NodeOptions & options)
   using std::placeholders::_1;
   using std::placeholders::_2;
 
+  const auto service_qos = rmw_qos_profile_services_default;
+
   auto_operator_change_ = declare_parameter("auto_operator_change", false);
   callback_group_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
 
@@ -40,12 +42,13 @@ AutowareEngage::AutowareEngage(const rclcpp::NodeOptions & options)
     "/api/operation_mode/state", rclcpp::QoS(1).transient_local(),
     std::bind(&AutowareEngage::on_state, this, _1));
   cli_change_stop_mode_ = create_client<ChangeOperationMode>(
-    "/api/operation_mode/change_to_stop", rmw_qos_profile_services_default, callback_group_);
+    "/api/operation_mode/change_to_stop", service_qos, callback_group_);
   cli_change_autonomous_mode_ = create_client<ChangeOperationMode>(
-    "/api/operation_mode/change_to_autonomous", rmw_qos_profile_services_default, callback_group_);
+    "/api/operation_mode/change_to_autonomous", service_qos, callback_group_);
   cli_enable_autoware_control_ = create_client<ChangeOperationMode>(
-    "/api/operation_mode/enable_autoware_control", rmw_qos_profile_services_default,
-    callback_group_);
+    "/api/operation_mode/enable_autoware_control", service_qos, callback_group_);
+  cli_disable_autoware_control_ = create_client<ChangeOperationMode>(
+    "/api/operation_mode/disable_autoware_control", service_qos, callback_group_);
 
   state_.mode = OperationModeState::UNKNOWN;
 }
@@ -81,8 +84,8 @@ void AutowareEngage::on_engage(
   }
 
   if (req->engage && auto_operator_change_) {
-    const auto [status, response] =
-      utils::sync_call<ChangeOperationMode>(cli_enable_autoware_control_, request);
+    const auto client = req->engage ? cli_enable_autoware_control_ : cli_disable_autoware_control_;
+    const auto [status, response] = utils::sync_call<ChangeOperationMode>(client, request);
     if (utils::is_error(status)) {
       res->status = status;
       return;

--- a/tier4_deprecated_api_adapter/src/autoware_engage.hpp
+++ b/tier4_deprecated_api_adapter/src/autoware_engage.hpp
@@ -53,7 +53,7 @@ private:
   void on_engage(
     const EngageService::Request::SharedPtr req, EngageService::Response::SharedPtr res);
 
-  bool auto_operator_change_;
+  bool autoware_control_change_;
   OperationModeState state_;
 };
 

--- a/tier4_deprecated_api_adapter/src/autoware_engage.hpp
+++ b/tier4_deprecated_api_adapter/src/autoware_engage.hpp
@@ -45,7 +45,7 @@ private:
   rclcpp::Subscription<OperationModeState>::SharedPtr sub_operation_mode_state_;
   rclcpp::Client<ChangeOperationMode>::SharedPtr cli_change_stop_mode_;
   rclcpp::Client<ChangeOperationMode>::SharedPtr cli_change_autonomous_mode_;
-  rclcpp::Client<ChangeOperationMode>::SharedPtr cli_change_autoware_control_;
+  rclcpp::Client<ChangeOperationMode>::SharedPtr cli_enable_autoware_control_;
 
   // Callbacks.
   void on_state(const OperationModeState & msg);

--- a/tier4_deprecated_api_adapter/src/autoware_engage.hpp
+++ b/tier4_deprecated_api_adapter/src/autoware_engage.hpp
@@ -1,0 +1,61 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE_ENGAGE_HPP_
+#define AUTOWARE_ENGAGE_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
+#include <autoware_adapi_v1_msgs/srv/change_operation_mode.hpp>
+#include <tier4_external_api_msgs/msg/engage_status.hpp>
+#include <tier4_external_api_msgs/srv/engage.hpp>
+
+namespace tier4_deprecated_api_adapter
+{
+
+using EngageService = tier4_external_api_msgs::srv::Engage;
+using EngageStatus = tier4_external_api_msgs::msg::EngageStatus;
+using ChangeOperationMode = autoware_adapi_v1_msgs::srv::ChangeOperationMode;
+using OperationModeState = autoware_adapi_v1_msgs::msg::OperationModeState;
+
+class AutowareEngage : public rclcpp::Node
+{
+public:
+  explicit AutowareEngage(const rclcpp::NodeOptions & options);
+
+private:
+  // TIER IV API
+  rclcpp::Publisher<EngageStatus>::SharedPtr pub_engage_;
+  rclcpp::Service<EngageService>::SharedPtr srv_engage_;
+
+  // AD API
+  rclcpp::CallbackGroup::SharedPtr callback_group_;
+  rclcpp::Subscription<OperationModeState>::SharedPtr sub_operation_mode_state_;
+  rclcpp::Client<ChangeOperationMode>::SharedPtr cli_change_stop_mode_;
+  rclcpp::Client<ChangeOperationMode>::SharedPtr cli_change_autonomous_mode_;
+  rclcpp::Client<ChangeOperationMode>::SharedPtr cli_change_autoware_control_;
+
+  // Callbacks.
+  void on_state(const OperationModeState & msg);
+  void on_engage(
+    const EngageService::Request::SharedPtr req, EngageService::Response::SharedPtr res);
+
+  bool auto_operator_change_;
+  OperationModeState state_;
+};
+
+}  // namespace tier4_deprecated_api_adapter
+
+#endif  // AUTOWARE_ENGAGE_HPP_

--- a/tier4_deprecated_api_adapter/src/autoware_engage.hpp
+++ b/tier4_deprecated_api_adapter/src/autoware_engage.hpp
@@ -46,6 +46,7 @@ private:
   rclcpp::Client<ChangeOperationMode>::SharedPtr cli_change_stop_mode_;
   rclcpp::Client<ChangeOperationMode>::SharedPtr cli_change_autonomous_mode_;
   rclcpp::Client<ChangeOperationMode>::SharedPtr cli_enable_autoware_control_;
+  rclcpp::Client<ChangeOperationMode>::SharedPtr cli_disable_autoware_control_;
 
   // Callbacks.
   void on_state(const OperationModeState & msg);

--- a/tier4_deprecated_api_adapter/src/utils/client.hpp
+++ b/tier4_deprecated_api_adapter/src/utils/client.hpp
@@ -1,4 +1,4 @@
-// Copyright 2021 Tier IV, Inc.
+// Copyright 2021 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tier4_deprecated_api_adapter/src/utils/client.hpp
+++ b/tier4_deprecated_api_adapter/src/utils/client.hpp
@@ -1,0 +1,48 @@
+// Copyright 2021 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef UTILS__CLIENT_HPP_
+#define UTILS__CLIENT_HPP_
+
+#include "response.hpp"
+
+#include <chrono>
+#include <utility>
+
+namespace tier4_deprecated_api_adapter::utils
+{
+
+using ResponseStatus = tier4_external_api_msgs::msg::ResponseStatus;
+
+template <typename ServiceT>
+std::pair<ResponseStatus, typename ServiceT::Response::SharedPtr> sync_call(
+  typename rclcpp::Client<ServiceT>::SharedPtr client,
+  const typename ServiceT::Request::SharedPtr & request,
+  const std::chrono::nanoseconds & timeout = std::chrono::seconds(2))
+{
+  if (!client->service_is_ready()) {
+    return {response_error("Internal service is not available."), nullptr};
+  }
+
+  auto future = client->async_send_request(request);
+  if (future.wait_for(timeout) != std::future_status::ready) {
+    return {response_error("Internal service has timed out."), nullptr};
+  }
+
+  return {response_success(), future.get()};
+}
+
+}  // namespace tier4_deprecated_api_adapter::utils
+
+#endif  // UTILS__CLIENT_HPP_

--- a/tier4_deprecated_api_adapter/src/utils/response.hpp
+++ b/tier4_deprecated_api_adapter/src/utils/response.hpp
@@ -1,0 +1,77 @@
+// Copyright 2021 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef UTILS__RESPONSE_HPP_
+#define UTILS__RESPONSE_HPP_
+
+#include <tier4_external_api_msgs/msg/response_status.hpp>
+
+#include <string>
+
+namespace tier4_deprecated_api_adapter::utils
+{
+
+using ResponseStatus = tier4_external_api_msgs::msg::ResponseStatus;
+
+inline bool is_success(const tier4_external_api_msgs::msg::ResponseStatus & status)
+{
+  return status.code == tier4_external_api_msgs::msg::ResponseStatus::SUCCESS;
+}
+
+inline bool is_ignored(const tier4_external_api_msgs::msg::ResponseStatus & status)
+{
+  return status.code == tier4_external_api_msgs::msg::ResponseStatus::IGNORED;
+}
+
+inline bool is_warn(const tier4_external_api_msgs::msg::ResponseStatus & status)
+{
+  return status.code == tier4_external_api_msgs::msg::ResponseStatus::WARN;
+}
+
+inline bool is_error(const tier4_external_api_msgs::msg::ResponseStatus & status)
+{
+  return status.code == tier4_external_api_msgs::msg::ResponseStatus::ERROR;
+}
+
+inline ResponseStatus response_success(const std::string & message = "")
+{
+  return tier4_external_api_msgs::build<tier4_external_api_msgs::msg::ResponseStatus>()
+    .code(tier4_external_api_msgs::msg::ResponseStatus::SUCCESS)
+    .message(message);
+}
+
+inline ResponseStatus response_ignored(const std::string & message = "")
+{
+  return tier4_external_api_msgs::build<tier4_external_api_msgs::msg::ResponseStatus>()
+    .code(tier4_external_api_msgs::msg::ResponseStatus::IGNORED)
+    .message(message);
+}
+
+inline ResponseStatus response_warn(const std::string & message = "")
+{
+  return tier4_external_api_msgs::build<tier4_external_api_msgs::msg::ResponseStatus>()
+    .code(tier4_external_api_msgs::msg::ResponseStatus::WARN)
+    .message(message);
+}
+
+inline ResponseStatus response_error(const std::string & message = "")
+{
+  return tier4_external_api_msgs::build<tier4_external_api_msgs::msg::ResponseStatus>()
+    .code(tier4_external_api_msgs::msg::ResponseStatus::ERROR)
+    .message(message);
+}
+
+}  // namespace tier4_deprecated_api_adapter::utils
+
+#endif  // UTILS__RESPONSE_HPP_


### PR DESCRIPTION
## Description

The engage API uses operation mode API instead of internal interface for maintainability.
Note that sources under utils directory are from tier4_api_utils.

## Test

[TIER IV internal link](https://evaluation.tier4.jp/evaluation/reports/6f4cf145-4e5a-5a85-8076-25a5993863b8?project_id=prd_jt)