### PR TITLE
feat(autoware_iv_external_api_adaptor): add system monitor API

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ If the version is empty, it means version v0.4.0 or earlier.
 | -       | topic   | [/api/external/get/rosbag_logging_mode](./doc/api/external/get/rosbag_logging_mode.md)                         | [tier4_external_api_msgs/msg/RosbagLoggingMode](https://github.com/tier4/tier4_autoware_msgs/blob/tier4/universe/tier4_external_api_msgs/msg/RosbagLoggingMode.msg)                             |
 | -       | topic   | [/api/external/get/calibration_status](./doc/api/external/get/calibration_status.md)                           | [tier4_external_api_msgs/msg/CalibrationStatusArray](https://github.com/tier4/tier4_autoware_msgs/blob/tier4/universe/tier4_external_api_msgs/msg/CalibrationStatusArray.msg)                   |
 | -       | service | [/api/external/get/accel_brake_map_calibrator/data](./doc/api/external/get/accel_brake_map_calibrator/data.md) | [tier4_external_api_msgs/srv/GetAccelBrakeMapCalibrationData](https://github.com/tier4/tier4_autoware_msgs/blob/tier4/universe/tier4_external_api_msgs/srv/GetAccelBrakeMapCalibrationData.srv) |
+| -       | topic   | [/api/external/get/system_monitor](./doc/api/external/get/system_monitor.md)                                   | [tier4_external_api_msgs/msg/SystemMonitor](https://github.com/tier4/tier4_autoware_msgs/blob/tier4/universe/tier4_external_api_msgs/msg/SystemMonitor.msg)                                     |
 
 ## Deprecated API
 

--- a/autoware_iv_external_api_adaptor/CMakeLists.txt
+++ b/autoware_iv_external_api_adaptor/CMakeLists.txt
@@ -22,6 +22,7 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/rtc_controller.cpp
   src/service.cpp
   src/start.cpp
+  src/system_monitor.cpp
   src/vehicle_status.cpp
   src/velocity.cpp
   src/version.cpp
@@ -45,6 +46,7 @@ rclcpp_components_register_nodes(${PROJECT_NAME}
   "external_api::RTCController"
   "external_api::Service"
   "external_api::Start"
+  "external_api::SystemMonitor"
   "external_api::VehicleStatus"
   "external_api::Velocity"
   "external_api::Version"

--- a/autoware_iv_external_api_adaptor/launch/external_api_adaptor.launch.py
+++ b/autoware_iv_external_api_adaptor/launch/external_api_adaptor.launch.py
@@ -45,6 +45,7 @@ def generate_launch_description():
         _create_api_node("route", "Route"),
         _create_api_node("service", "Service"),
         _create_api_node("start", "Start"),
+        _create_api_node("system_monitor", "SystemMonitor"),
         _create_api_node("vehicle_status", "VehicleStatus"),
         _create_api_node("velocity", "Velocity"),
         _create_api_node("version", "Version"),

--- a/autoware_iv_external_api_adaptor/src/system_monitor.cpp
+++ b/autoware_iv_external_api_adaptor/src/system_monitor.cpp
@@ -30,43 +30,61 @@ SystemMonitor::SystemMonitor(const rclcpp::NodeOptions & options) : Node("system
     "/system/system_monitor/cpu_monitor/cpu_temperature", rclcpp::QoS(1),
     [this](const tier4_external_api_msgs::msg::CpuTemperature::SharedPtr msg) {
       msg_system_monitor_[msg->hostname].cpu_temperature = *msg;
+      tryPublishMsg(msg->hostname);
     });
 
   sub_memory_status_ = create_subscription<tier4_external_api_msgs::msg::MemoryStatus>(
     "/system/system_monitor/mem_monitor/memory_status", rclcpp::QoS(1),
     [this](const tier4_external_api_msgs::msg::MemoryStatus::SharedPtr msg) {
       msg_system_monitor_[msg->hostname].memory_status = *msg;
+      tryPublishMsg(msg->hostname);
     });
 
   sub_gpu_status_ = create_subscription<tier4_external_api_msgs::msg::GpuStatus>(
     "/system/system_monitor/gpu_monitor/gpu_status", rclcpp::QoS(1),
     [this](const tier4_external_api_msgs::msg::GpuStatus::SharedPtr msg) {
       msg_system_monitor_[msg->hostname].gpu_status = *msg;
+      tryPublishMsg(msg->hostname);
     });
 
   sub_network_status_ = create_subscription<tier4_external_api_msgs::msg::NetworkStatus>(
     "/system/system_monitor/net_monitor/network_status", rclcpp::QoS(1),
     [this](const tier4_external_api_msgs::msg::NetworkStatus::SharedPtr msg) {
       msg_system_monitor_[msg->hostname].network_status = *msg;
+      tryPublishMsg(msg->hostname);
     });
 
   sub_hdd_status_ = create_subscription<tier4_external_api_msgs::msg::HddStatus>(
     "/system/system_monitor/hdd_monitor/hdd_status", rclcpp::QoS(1),
     [this](const tier4_external_api_msgs::msg::HddStatus::SharedPtr msg) {
       msg_system_monitor_[msg->hostname].hdd_status = *msg;
+      tryPublishMsg(msg->hostname);
     });
-
-  // Timer callback
-  timer_ =
-    rclcpp::create_timer(this, get_clock(), 1s, std::bind(&SystemMonitor::callbackTimer, this));
 }
 
-void SystemMonitor::callbackTimer()
+bool SystemMonitor::isComplete(const tier4_external_api_msgs::msg::SystemMonitor & msg)
 {
-  for (auto & [hostname, msg] : msg_system_monitor_) {
+  // Checks whether all fields in the SystemMonitor message are filled.
+  // The timestamp fields are initialized to zero by the default constructor,
+  // so a non-zero value indicates that the corresponding message was received.
+  return msg.cpu_temperature.stamp.sec != 0 &&
+         msg.memory_status.stamp.sec != 0 &&
+         msg.gpu_status.stamp.sec != 0 &&
+         msg.network_status.stamp.sec != 0 &&
+         msg.hdd_status.stamp.sec != 0;
+}
+
+void SystemMonitor::tryPublishMsg(const std::string & hostname)
+{
+  auto it = msg_system_monitor_.find(hostname);
+  if (it == msg_system_monitor_.end()) return;
+
+  auto & msg = it->second;
+  if (isComplete(msg)) {
     msg.hostname = hostname;
     msg.stamp = this->now();
     pub_system_monitor_->publish(msg);
+    msg_system_monitor_.erase(it);
   }
 }
 

--- a/autoware_iv_external_api_adaptor/src/system_monitor.cpp
+++ b/autoware_iv_external_api_adaptor/src/system_monitor.cpp
@@ -57,12 +57,13 @@ SystemMonitor::SystemMonitor(const rclcpp::NodeOptions & options) : Node("system
     });
 
   // Timer callback
-  timer_ = rclcpp::create_timer(this, get_clock(), 1s, std::bind(&SystemMonitor::callbackTimer, this));
+  timer_ =
+    rclcpp::create_timer(this, get_clock(), 1s, std::bind(&SystemMonitor::callbackTimer, this));
 }
 
 void SystemMonitor::callbackTimer()
 {
-  for (auto& [hostname, msg] : msg_system_monitor_) {
+  for (auto & [hostname, msg] : msg_system_monitor_) {
     msg.hostname = hostname;
     msg.stamp = this->now();
     pub_system_monitor_->publish(msg);

--- a/autoware_iv_external_api_adaptor/src/system_monitor.cpp
+++ b/autoware_iv_external_api_adaptor/src/system_monitor.cpp
@@ -67,10 +67,8 @@ bool SystemMonitor::isComplete(const tier4_external_api_msgs::msg::SystemMonitor
   // Checks whether all fields in the SystemMonitor message are filled.
   // The timestamp fields are initialized to zero by the default constructor,
   // so a non-zero value indicates that the corresponding message was received.
-  return msg.cpu_temperature.stamp.sec != 0 &&
-         msg.memory_status.stamp.sec != 0 &&
-         msg.gpu_status.stamp.sec != 0 &&
-         msg.network_status.stamp.sec != 0 &&
+  return msg.cpu_temperature.stamp.sec != 0 && msg.memory_status.stamp.sec != 0 &&
+         msg.gpu_status.stamp.sec != 0 && msg.network_status.stamp.sec != 0 &&
          msg.hdd_status.stamp.sec != 0;
 }
 

--- a/autoware_iv_external_api_adaptor/src/system_monitor.cpp
+++ b/autoware_iv_external_api_adaptor/src/system_monitor.cpp
@@ -1,0 +1,75 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "system_monitor.hpp"
+
+namespace external_api
+{
+
+SystemMonitor::SystemMonitor(const rclcpp::NodeOptions & options) : Node("system_monitor", options)
+{
+  using namespace std::literals::chrono_literals;
+
+  // Publisher
+  pub_system_monitor_ = this->create_publisher<tier4_external_api_msgs::msg::SystemMonitor>(
+    "/api/external/get/system_monitor", rclcpp::QoS(1));
+
+  // Subscriber
+  sub_cpu_temperature_ = create_subscription<tier4_external_api_msgs::msg::CpuTemperature>(
+    "/system/system_monitor/cpu_monitor/cpu_temperature", rclcpp::QoS(1),
+    [this](const tier4_external_api_msgs::msg::CpuTemperature::SharedPtr msg) {
+      msg_system_monitor_[msg->hostname].cpu_temperature = *msg;
+    });
+
+  sub_memory_status_ = create_subscription<tier4_external_api_msgs::msg::MemoryStatus>(
+    "/system/system_monitor/mem_monitor/memory_status", rclcpp::QoS(1),
+    [this](const tier4_external_api_msgs::msg::MemoryStatus::SharedPtr msg) {
+      msg_system_monitor_[msg->hostname].memory_status = *msg;
+    });
+
+  sub_gpu_status_ = create_subscription<tier4_external_api_msgs::msg::GpuStatus>(
+    "/system/system_monitor/gpu_monitor/gpu_status", rclcpp::QoS(1),
+    [this](const tier4_external_api_msgs::msg::GpuStatus::SharedPtr msg) {
+      msg_system_monitor_[msg->hostname].gpu_status = *msg;
+    });
+
+  sub_network_status_ = create_subscription<tier4_external_api_msgs::msg::NetworkStatus>(
+    "/system/system_monitor/net_monitor/network_status", rclcpp::QoS(1),
+    [this](const tier4_external_api_msgs::msg::NetworkStatus::SharedPtr msg) {
+      msg_system_monitor_[msg->hostname].network_status = *msg;
+    });
+
+  sub_hdd_status_ = create_subscription<tier4_external_api_msgs::msg::HddStatus>(
+    "/system/system_monitor/hdd_monitor/hdd_status", rclcpp::QoS(1),
+    [this](const tier4_external_api_msgs::msg::HddStatus::SharedPtr msg) {
+      msg_system_monitor_[msg->hostname].hdd_status = *msg;
+    });
+
+  // Timer callback
+  timer_ = rclcpp::create_timer(this, get_clock(), 1s, std::bind(&SystemMonitor::callbackTimer, this));
+}
+
+void SystemMonitor::callbackTimer()
+{
+  for (auto& [hostname, msg] : msg_system_monitor_) {
+    msg.hostname = hostname;
+    msg.stamp = this->now();
+    pub_system_monitor_->publish(msg);
+  }
+}
+
+}  // namespace external_api
+
+#include <rclcpp_components/register_node_macro.hpp>
+RCLCPP_COMPONENTS_REGISTER_NODE(external_api::SystemMonitor)

--- a/autoware_iv_external_api_adaptor/src/system_monitor.hpp
+++ b/autoware_iv_external_api_adaptor/src/system_monitor.hpp
@@ -40,9 +40,8 @@ public:
   explicit SystemMonitor(const rclcpp::NodeOptions & options);
 
 private:
-  void callbackTimer();
-
-  rclcpp::TimerBase::SharedPtr timer_;
+  bool isComplete(const tier4_external_api_msgs::msg::SystemMonitor & msg);
+  void tryPublishMsg(const std::string & hostname);
 
   std::map<std::string, tier4_external_api_msgs::msg::SystemMonitor> msg_system_monitor_;
 

--- a/autoware_iv_external_api_adaptor/src/system_monitor.hpp
+++ b/autoware_iv_external_api_adaptor/src/system_monitor.hpp
@@ -1,0 +1,57 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SYSTEM_MONITOR_HPP_
+#define SYSTEM_MONITOR_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+#include "tier4_api_utils/tier4_api_utils.hpp"
+
+#include "tier4_external_api_msgs/msg/system_monitor.hpp"
+#include "tier4_external_api_msgs/msg/cpu_temperature.hpp"
+#include "tier4_external_api_msgs/msg/memory_status.hpp"
+#include "tier4_external_api_msgs/msg/gpu_status.hpp"
+#include "tier4_external_api_msgs/msg/network_status.hpp"
+#include "tier4_external_api_msgs/msg/hdd_status.hpp"
+
+#include <memory>
+#include <utility>
+
+namespace external_api
+{
+
+class SystemMonitor : public rclcpp::Node
+{
+public:
+  explicit SystemMonitor(const rclcpp::NodeOptions & options);
+
+private:
+  void callbackTimer();
+
+  rclcpp::TimerBase::SharedPtr timer_;
+
+  std::map<std::string, tier4_external_api_msgs::msg::SystemMonitor> msg_system_monitor_;
+
+  rclcpp::Publisher<tier4_external_api_msgs::msg::SystemMonitor>::SharedPtr pub_system_monitor_;
+
+  rclcpp::Subscription<tier4_external_api_msgs::msg::CpuTemperature>::SharedPtr sub_cpu_temperature_;
+  rclcpp::Subscription<tier4_external_api_msgs::msg::MemoryStatus>::SharedPtr sub_memory_status_;
+  rclcpp::Subscription<tier4_external_api_msgs::msg::GpuStatus>::SharedPtr sub_gpu_status_;
+  rclcpp::Subscription<tier4_external_api_msgs::msg::NetworkStatus>::SharedPtr sub_network_status_;
+  rclcpp::Subscription<tier4_external_api_msgs::msg::HddStatus>::SharedPtr sub_hdd_status_;
+};
+
+}  // namespace external_api
+
+#endif  // SYSTEM_MONITOR_HPP_

--- a/autoware_iv_external_api_adaptor/src/system_monitor.hpp
+++ b/autoware_iv_external_api_adaptor/src/system_monitor.hpp
@@ -15,15 +15,16 @@
 #ifndef SYSTEM_MONITOR_HPP_
 #define SYSTEM_MONITOR_HPP_
 
-#include <rclcpp/rclcpp.hpp>
 #include "tier4_api_utils/tier4_api_utils.hpp"
 
-#include "tier4_external_api_msgs/msg/system_monitor.hpp"
+#include <rclcpp/rclcpp.hpp>
+
 #include "tier4_external_api_msgs/msg/cpu_temperature.hpp"
-#include "tier4_external_api_msgs/msg/memory_status.hpp"
 #include "tier4_external_api_msgs/msg/gpu_status.hpp"
-#include "tier4_external_api_msgs/msg/network_status.hpp"
 #include "tier4_external_api_msgs/msg/hdd_status.hpp"
+#include "tier4_external_api_msgs/msg/memory_status.hpp"
+#include "tier4_external_api_msgs/msg/network_status.hpp"
+#include "tier4_external_api_msgs/msg/system_monitor.hpp"
 
 #include <memory>
 #include <utility>
@@ -45,7 +46,8 @@ private:
 
   rclcpp::Publisher<tier4_external_api_msgs::msg::SystemMonitor>::SharedPtr pub_system_monitor_;
 
-  rclcpp::Subscription<tier4_external_api_msgs::msg::CpuTemperature>::SharedPtr sub_cpu_temperature_;
+  rclcpp::Subscription<tier4_external_api_msgs::msg::CpuTemperature>::SharedPtr
+    sub_cpu_temperature_;
   rclcpp::Subscription<tier4_external_api_msgs::msg::MemoryStatus>::SharedPtr sub_memory_status_;
   rclcpp::Subscription<tier4_external_api_msgs::msg::GpuStatus>::SharedPtr sub_gpu_status_;
   rclcpp::Subscription<tier4_external_api_msgs::msg::NetworkStatus>::SharedPtr sub_network_status_;

--- a/autoware_iv_external_api_adaptor/src/system_monitor.hpp
+++ b/autoware_iv_external_api_adaptor/src/system_monitor.hpp
@@ -26,7 +26,9 @@
 #include "tier4_external_api_msgs/msg/network_status.hpp"
 #include "tier4_external_api_msgs/msg/system_monitor.hpp"
 
+#include <map>
 #include <memory>
+#include <string>
 #include <utility>
 
 namespace external_api

--- a/awapi_awiv_adapter/Readme.md
+++ b/awapi_awiv_adapter/Readme.md
@@ -148,7 +148,6 @@
 - set temporary stop signal
 - MessageType: tier4_api_msgs/StopCommand
 - Specification
-
   - send True: send upper velocity to 0
   - send False: resend last received upper velocity
     - (if upper velocity have never received, send _default_max_velocity_ value.)

--- a/doc/api/external/get/system_monitor.md
+++ b/doc/api/external/get/system_monitor.md
@@ -1,0 +1,20 @@
+# /api/external/get/system_monitor
+
+## Classification
+
+- Behavior: Topic
+- DataType: tier4_external_api_msgs/msg/SystemMonitor
+
+## Description
+
+System Monitorの計測結果を取得する。取得できる値は以下の通り。
+
+- CPU温度、サーマルスロットリング状態
+- メモリ使用率
+- GPUの状態（GPU使用率、GPU温度、GPUサーマルスロットリング状態）
+- ネットワークの状態（通信帯域、エラー）
+- ディスクの状態（使用率、IOアクセス）
+
+## Requirement
+
+System Monitorの実装でサポートされている計測結果を提供すること。


### PR DESCRIPTION
## Related Links

- JIRA Ticket
  - https://tier4.atlassian.net/browse/RT0-38268
- Related documents
  - https://tier4.atlassian.net/wiki/spaces/SI/pages/3644819134
- This PR needs the following PR to build
  - https://github.com/tier4/tier4_autoware_msgs/pull/187
- This PR needs the following PRs to run
  - https://github.com/autowarefoundation/autoware_universe/pull/11024
  - https://github.com/autowarefoundation/autoware_universe/pull/11023
  - https://github.com/autowarefoundation/autoware_universe/pull/11022
  - https://github.com/autowarefoundation/autoware_universe/pull/11021
  - https://github.com/autowarefoundation/autoware_universe/pull/11020

## Description

- This PR is one of the PRs needed for metrics collection
- This PR adds `/api/external/get/system_monitor` API, which is received by [Metric Agent](https://github.com/tier4/autoware-metric-agent)

## Tests performed

- `/api/external/get/system_monitor` outputs the measured system performance

<img width="732" height="1569" alt="Screenshot from 2025-07-18 19-31-50" src="https://github.com/user-attachments/assets/13d603c1-b463-4c41-88d0-5d3247aafc8e" />

