### PR TITLE
feat: add api mode option

### DIFF
--- a/autoware_iv_external_api_adaptor/launch/external_api_adaptor.launch.py
+++ b/autoware_iv_external_api_adaptor/launch/external_api_adaptor.launch.py
@@ -66,17 +66,17 @@ def generate_launch_description():
         package="rclcpp_components",
         executable="component_container_mt",
         composable_node_descriptions=components3,
-        ros_arguments=["--log-level", "external.autoware_iv_adaptor:=WARN"],
+        ros_arguments=["--log-level", "autoware_api.external.autoware_iv_adaptor:=WARN"],
         output="screen",
     )
     loader1 = LoadComposableNodes(
         composable_node_descriptions=components1,
-        target_container="/external/autoware_iv_adaptor",
+        target_container="/autoware_api/external/autoware_iv_adaptor",
         condition=IfCondition(PythonExpression([LaunchConfiguration("api_mode"), " < 1"])),
     )
     loader2 = LoadComposableNodes(
         composable_node_descriptions=components2,
-        target_container="/external/autoware_iv_adaptor",
+        target_container="/autoware_api/external/autoware_iv_adaptor",
         condition=IfCondition(PythonExpression([LaunchConfiguration("api_mode"), " < 2"])),
     )
 

--- a/autoware_iv_external_api_adaptor/launch/external_api_adaptor.launch.py
+++ b/autoware_iv_external_api_adaptor/launch/external_api_adaptor.launch.py
@@ -13,7 +13,12 @@
 # limitations under the License.
 
 import launch
+from launch.actions import DeclareLaunchArgument
+from launch.conditions import IfCondition
+from launch.substitutions import LaunchConfiguration
+from launch.substitutions import PythonExpression
 from launch_ros.actions import ComposableNodeContainer
+from launch_ros.actions import LoadComposableNodes
 from launch_ros.descriptions import ComposableNode
 
 
@@ -29,33 +34,51 @@ def _create_api_node(node_name, class_name, **kwargs):
 
 def generate_launch_description():
     # RTCController is launched by tier4_autoware_api_launch because it is used by autoware_universe.
-    components = [
-        _create_api_node("calibration_status", "CalibrationStatus"),
-        _create_api_node("cpu_usage", "CpuUsage"),
+    components1 = [
+        _create_api_node("service", "Service"),
+    ]
+    components2 = [
         _create_api_node("diagnostics", "Diagnostics"),
         _create_api_node("door", "Door"),
         _create_api_node("emergency", "Emergency"),
         _create_api_node("fail_safe_state", "FailSafeState"),
         _create_api_node("initial_pose", "InitialPose"),
-        _create_api_node("localization_score", "LocalizationScore"),
-        _create_api_node("map", "Map"),
         _create_api_node("operator", "Operator"),
-        _create_api_node("rosbag_logging_mode", "RosbagLoggingMode"),
-        _create_api_node("metadata_packages", "MetadataPackages"),
         _create_api_node("route", "Route"),
-        _create_api_node("service", "Service"),
         _create_api_node("start", "Start"),
-        _create_api_node("system_monitor", "SystemMonitor"),
         _create_api_node("vehicle_status", "VehicleStatus"),
         _create_api_node("velocity", "Velocity"),
+    ]
+    components3 = [
+        _create_api_node("calibration_status", "CalibrationStatus"),
+        _create_api_node("cpu_usage", "CpuUsage"),
+        _create_api_node("localization_score", "LocalizationScore"),
+        _create_api_node("map", "Map"),
+        _create_api_node("metadata_packages", "MetadataPackages"),
+        _create_api_node("rosbag_logging_mode", "RosbagLoggingMode"),
+        _create_api_node("system_monitor", "SystemMonitor"),
         _create_api_node("version", "Version"),
     ]
+
     container = ComposableNodeContainer(
         namespace="external",
         name="autoware_iv_adaptor",
         package="rclcpp_components",
         executable="component_container_mt",
-        composable_node_descriptions=components,
+        composable_node_descriptions=components3,
+        ros_arguments=["--log-level", "external.autoware_iv_adaptor:=WARN"],
         output="screen",
     )
-    return launch.LaunchDescription([container])
+    loader1 = LoadComposableNodes(
+        composable_node_descriptions=components1,
+        target_container="/external/autoware_iv_adaptor",
+        condition=IfCondition(PythonExpression([LaunchConfiguration("api_mode"), " < 1"])),
+    )
+    loader2 = LoadComposableNodes(
+        composable_node_descriptions=components2,
+        target_container="/external/autoware_iv_adaptor",
+        condition=IfCondition(PythonExpression([LaunchConfiguration("api_mode"), " < 2"])),
+    )
+
+    argument = DeclareLaunchArgument("api_mode", default_value="0")
+    return launch.LaunchDescription([argument, container, loader1, loader2])

--- a/awapi_awiv_adapter/launch/awapi_awiv_adapter.launch.xml
+++ b/awapi_awiv_adapter/launch/awapi_awiv_adapter.launch.xml
@@ -77,7 +77,6 @@
   <arg name="set_path_change_approval" default="path_change/put/approval"/>
   <arg name="set_path_change_force" default="path_change/put/force"/>
   <arg name="set_obstacle_avoid_approval" default="object_avoidance/put/approval"/>
-  <arg name="set_force_obstacle_avoid" default="object_avoidance/put/force"/>
   <arg name="set_overwrite_traffic_signals" default="traffic_light/put/traffic_signals"/>
   <arg name="set_crosswalk_status" default="autoware/put/crosswalk_states"/>
   <arg name="set_intersection_status" default="autoware/put/intersection_states"/>
@@ -98,7 +97,7 @@
   <arg name="use_intra_process" default="false"/>
   <arg name="use_multithread" default="false"/>
 
-  <group if="$(eval &quot; $(var api_mode) &lt;= 1 &quot;)">
+  <group if="$(eval &quot; $(var api_mode) &lt; 2 &quot;)">
     <push-ros-namespace namespace="awapi"/>
     <node pkg="awapi_awiv_adapter" exec="awapi_awiv_adapter" output="screen">
       <remap from="input/steer" to="$(var input_steer)"/>
@@ -146,7 +145,7 @@
     </node>
   </group>
 
-  <group if="$(eval &quot; $(var api_mode) &lt;= 0 &quot;)">
+  <group if="$(eval &quot; $(var api_mode) &lt; 1 &quot;)">
     <include file="$(find-pkg-share awapi_awiv_adapter)/launch/awapi_relay_container.launch.py"/>
   </group>
 </launch>

--- a/awapi_awiv_adapter/launch/awapi_awiv_adapter.launch.xml
+++ b/awapi_awiv_adapter/launch/awapi_awiv_adapter.launch.xml
@@ -1,4 +1,5 @@
 <launch>
+  <arg name="api_mode" default="0"/>
   <arg name="use_control_command_gate" default="false"/>
   <arg name="adapter_output" default="screen"/>
   <arg name="relay_output" default="log"/>
@@ -97,7 +98,7 @@
   <arg name="use_intra_process" default="false"/>
   <arg name="use_multithread" default="false"/>
 
-  <group>
+  <group if="$(eval &quot; $(var api_mode) &lt;= 1 &quot;)">
     <push-ros-namespace namespace="awapi"/>
     <node pkg="awapi_awiv_adapter" exec="awapi_awiv_adapter" output="screen">
       <remap from="input/steer" to="$(var input_steer)"/>
@@ -141,8 +142,11 @@
       <param name="stop_reason_timeout" value="$(var stop_reason_timeout)"/>
       <param name="stop_reason_thresh_dist" value="$(var stop_reason_thresh_dist)"/>
       <param name="use_control_command_gate" value="$(var use_control_command_gate)"/>
+      <param name="api_mode" value="$(var api_mode)"/>
     </node>
   </group>
 
-  <include file="$(find-pkg-share awapi_awiv_adapter)/launch/awapi_relay_container.launch.py"/>
+  <group if="$(eval &quot; $(var api_mode) &lt;= 0 &quot;)">
+    <include file="$(find-pkg-share awapi_awiv_adapter)/launch/awapi_relay_container.launch.py"/>
+  </group>
 </launch>

--- a/awapi_awiv_adapter/src/awapi_awiv_adapter_core.cpp
+++ b/awapi_awiv_adapter/src/awapi_awiv_adapter_core.cpp
@@ -165,10 +165,14 @@ void AutowareIvAdapter::timerCallback()
   autoware_state_publisher_->statePublisher(aw_info_);
 
   // publish lane change state
-  lane_change_state_publisher_->statePublisher(aw_info_);
+  if (lane_change_state_publisher_) {
+    lane_change_state_publisher_->statePublisher(aw_info_);
+  }
 
   // publish obstacle_avoidance state
-  obstacle_avoidance_state_publisher_->statePublisher(aw_info_);
+  if (obstacle_avoidance_state_publisher_) {
+    obstacle_avoidance_state_publisher_->statePublisher(aw_info_);
+  }
 
   // publish v2x command and state
   if (aw_info_.v2x_command_ptr) {

--- a/awapi_awiv_adapter/src/awapi_awiv_adapter_core.cpp
+++ b/awapi_awiv_adapter/src/awapi_awiv_adapter_core.cpp
@@ -37,6 +37,7 @@ AutowareIvAdapter::AutowareIvAdapter()
       declare_parameter("param/emergency_stop", ""));
     emergencyParamCheck(em_stop_param);
   }
+  const auto api_mode = declare_parameter<int>("api_mode");
 
   // setup instance
   vehicle_state_publisher_ = std::make_unique<AutowareIvVehicleStatePublisher>(*this);
@@ -46,11 +47,14 @@ AutowareIvAdapter::AutowareIvAdapter()
   velocity_factor_converter_ =
     std::make_unique<AutowareIvVelocityFactorConverter>(*this, stop_reason_thresh_dist_);
   v2x_aggregator_ = std::make_unique<AutowareIvV2XAggregator>(*this);
-  lane_change_state_publisher_ = std::make_unique<AutowareIvLaneChangeStatePublisher>(*this);
-  obstacle_avoidance_state_publisher_ =
-    std::make_unique<AutowareIvObstacleAvoidanceStatePublisher>(*this);
   max_velocity_publisher_ =
     std::make_unique<AutowareIvMaxVelocityPublisher>(*this, default_max_velocity);
+
+  if (api_mode < 1) {
+    lane_change_state_publisher_ = std::make_unique<AutowareIvLaneChangeStatePublisher>(*this);
+    obstacle_avoidance_state_publisher_ =
+      std::make_unique<AutowareIvObstacleAvoidanceStatePublisher>(*this);
+  }
 
   // publisher
   pub_v2x_command_ = this->create_publisher<tier4_v2x_msgs::msg::InfrastructureCommandArray>(
@@ -116,17 +120,20 @@ AutowareIvAdapter::AutowareIvAdapter()
     this->create_subscription<autoware_planning_msgs::msg::Trajectory>(
       "input/obstacle_avoid_candidate_path", durable_qos,
       std::bind(&AutowareIvAdapter::callbackLaneObstacleAvoidCandidatePath, this, _1));
-  sub_max_velocity_ = this->create_subscription<tier4_api_msgs::msg::VelocityLimit>(
-    "input/max_velocity", 1, std::bind(&AutowareIvAdapter::callbackMaxVelocity, this, _1));
   sub_current_max_velocity_ =
     this->create_subscription<autoware_internal_planning_msgs::msg::VelocityLimit>(
       "input/current_max_velocity", durable_qos,
       std::bind(&AutowareIvAdapter::callbackCurrentMaxVelocity, this, _1));
-  sub_temporary_stop_ = this->create_subscription<tier4_api_msgs::msg::StopCommand>(
-    "input/temporary_stop", 1, std::bind(&AutowareIvAdapter::callbackTemporaryStop, this, _1));
   sub_autoware_traj_ = this->create_subscription<autoware_planning_msgs::msg::Trajectory>(
     "input/autoware_trajectory", 1,
     std::bind(&AutowareIvAdapter::callbackAutowareTrajectory, this, _1));
+
+  if (api_mode < 1) {
+    sub_temporary_stop_ = this->create_subscription<tier4_api_msgs::msg::StopCommand>(
+      "input/temporary_stop", 1, std::bind(&AutowareIvAdapter::callbackTemporaryStop, this, _1));
+    sub_max_velocity_ = this->create_subscription<tier4_api_msgs::msg::VelocityLimit>(
+      "input/max_velocity", 1, std::bind(&AutowareIvAdapter::callbackMaxVelocity, this, _1));
+  }
 
   // timer
   auto timer_callback = std::bind(&AutowareIvAdapter::timerCallback, this);


### PR DESCRIPTION
Add api mode option. See https://github.com/autowarefoundation/autoware_universe/pull/11121 for test.
- `api_mode:=0` : Launch all APIs (default)
- `api_mode:=1` : APIs up to EOL 2025/09 will not be launched.
- `api_mode:=2` : APIs up to EOL 2025/12 will not be launched.