### PR TITLE
ci: use beta/v0.48 in build depends

### DIFF
--- a/build_depends.repos
+++ b/build_depends.repos
@@ -14,4 +14,4 @@ repositories:
   universe/tier4_autoware_msgs:
     type: git
     url: https://github.com/tier4/tier4_autoware_msgs.git
-    version: tier4/universe
+    version: beta/v0.48


### PR DESCRIPTION
Use beta/v0.48 for build depends.