### PR TITLE
fix(tier4_deprecated_api_adapter): keep old route distance topic

### DIFF
--- a/tier4_deprecated_api_adapter/launch/tier4_deprecated_api_adapter.launch.xml
+++ b/tier4_deprecated_api_adapter/launch/tier4_deprecated_api_adapter.launch.xml
@@ -13,5 +13,11 @@
         <param name="mode" value="remote"/>
       </node>
     </group>
+
+    <node pkg="topic_tools" exec="relay" name="relay_route_distance">
+      <param name="input_topic" value="/tier4_api/utils/path_distance_calculator/distance"/>
+      <param name="output_topic" value="/autoware_api/utils/path_distance_calculator/distance"/>
+      <param name="type" value="autoware_internal_debug_msgs/msg/Float64Stamped"/>
+    </node>
   </group>
 </launch>

--- a/tier4_deprecated_api_adapter/package.xml
+++ b/tier4_deprecated_api_adapter/package.xml
@@ -17,6 +17,9 @@
   <depend>rclcpp_components</depend>
   <depend>tier4_external_api_msgs</depend>
 
+  <exec_depend>autoware_internal_debug_msgs</exec_depend>
+  <exec_depend>topic_tools</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 


### PR DESCRIPTION
## Description
Fix to keep old route distance topic name.
Cherry-pick
- https://github.com/tier4/tier4_ad_api_adaptor/pull/176

Related: [TIER IV INTERNAL](https://tier4.atlassian.net/browse/RT0-39869?atlOrigin=eyJpIjoiMDFjMTA5YzdjYTYxNGI0MmFiYzhjYjZkYTdhYjcyNjAiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)