### PR TITLE
feat(tier4_autoware_api_extension): add missing planning factors

### DIFF
--- a/tier4_autoware_api_extension/config/planning_factors.param.yaml
+++ b/tier4_autoware_api_extension/config/planning_factors.param.yaml
@@ -37,3 +37,6 @@
       - /planning/planning_factors/walkway
       - /planning/planning_factors/roundabout
       - /planning/planning_factors/road_user_stop
+      - /planning/planning_factors/intersection_collision_checker
+      - /planning/planning_factors/intersection_occlusion
+      - /planning/planning_factors/rear_collision_checker


### PR DESCRIPTION
add `intersection_collision_checker`,  `intersection_occlusion`,  `rear_collision_checker` planning factor to config.