### PR TITLE
feat: use component container to launch api nodes

### DIFF
--- a/autoware_iv_internal_api_adaptor/launch/internal_api_relay.launch.xml
+++ b/autoware_iv_internal_api_adaptor/launch/internal_api_relay.launch.xml
@@ -1,7 +1,10 @@
 <launch>
   <group>
     <push-ros-namespace namespace="internal"/>
-    <node_container pkg="rclcpp_components" exec="component_container" name="internal_api_relay_container" namespace="">
+    <node_container pkg="rclcpp_components" exec="component_container" name="internal_api_relay_container" namespace=""/>
+
+    <include file="$(find-pkg-share autoware_iv_internal_api_adaptor)/launch/namespace.launch.py"/>
+    <load_composable_node target="$(var current_ros_namespace)/internal_api_relay_container">
       <composable_node pkg="topic_tools" plugin="topic_tools::RelayNode" name="traffic_signals">
         <param name="input_topic" value="/api/autoware/set/traffic_signals"/>
         <param name="output_topic" value="/external/traffic_light_recognition/traffic_signals"/>
@@ -17,6 +20,6 @@
         <param name="output_topic" value="/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/input/external_crosswalk_states"/>
         <param name="type" value="tier4_api_msgs/msg/CrosswalkStatus"/>
       </composable_node>
-    </node_container>
+    </load_composable_node>
   </group>
 </launch>

--- a/autoware_iv_internal_api_adaptor/launch/internal_api_relay.launch.xml
+++ b/autoware_iv_internal_api_adaptor/launch/internal_api_relay.launch.xml
@@ -1,20 +1,22 @@
 <launch>
   <group>
     <push-ros-namespace namespace="internal"/>
-    <node pkg="topic_tools" exec="relay" name="traffic_signals">
-      <param name="input_topic" value="/api/autoware/set/traffic_signals"/>
-      <param name="output_topic" value="/external/traffic_light_recognition/traffic_signals"/>
-      <param name="type" value="autoware_perception_msgs/msg/TrafficSignalArray"/>
-    </node>
-    <node pkg="topic_tools" exec="relay" name="intersection_states">
-      <param name="input_topic" value="/api/autoware/set/intersection_states"/>
-      <param name="output_topic" value="/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/input/external_intersection_states"/>
-      <param name="type" value="tier4_api_msgs/msg/IntersectionStatus"/>
-    </node>
-    <node pkg="topic_tools" exec="relay" name="crosswalk_states">
-      <param name="input_topic" value="/api/autoware/set/crosswalk_states"/>
-      <param name="output_topic" value="/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/input/external_crosswalk_states"/>
-      <param name="type" value="tier4_api_msgs/msg/CrosswalkStatus"/>
-    </node>
+    <node_container pkg="rclcpp_components" exec="component_container" name="internal_api_relay_container" namespace="">
+      <composable_node pkg="topic_tools" plugin="topic_tools::RelayNode" name="traffic_signals">
+        <param name="input_topic" value="/api/autoware/set/traffic_signals"/>
+        <param name="output_topic" value="/external/traffic_light_recognition/traffic_signals"/>
+        <param name="type" value="autoware_perception_msgs/msg/TrafficSignalArray"/>
+      </composable_node>
+      <composable_node pkg="topic_tools" plugin="topic_tools::RelayNode" name="intersection_states">
+        <param name="input_topic" value="/api/autoware/set/intersection_states"/>
+        <param name="output_topic" value="/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/input/external_intersection_states"/>
+        <param name="type" value="tier4_api_msgs/msg/IntersectionStatus"/>
+      </composable_node>
+      <composable_node pkg="topic_tools" plugin="topic_tools::RelayNode" name="crosswalk_states">
+        <param name="input_topic" value="/api/autoware/set/crosswalk_states"/>
+        <param name="output_topic" value="/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/input/external_crosswalk_states"/>
+        <param name="type" value="tier4_api_msgs/msg/CrosswalkStatus"/>
+      </composable_node>
+    </node_container>
   </group>
 </launch>

--- a/autoware_iv_internal_api_adaptor/launch/namespace.launch.py
+++ b/autoware_iv_internal_api_adaptor/launch/namespace.launch.py
@@ -1,0 +1,10 @@
+from launch import LaunchDescription
+from launch.actions import SetLaunchConfiguration
+from launch.actions import OpaqueFunction
+
+def current_ros_namespace(context):
+    namespace = context.launch_configurations.get("ros_namespace", "")
+    return [SetLaunchConfiguration("current_ros_namespace", namespace)]
+
+def generate_launch_description():
+    return LaunchDescription([OpaqueFunction(function=current_ros_namespace)])

--- a/autoware_iv_internal_api_adaptor/launch/namespace.launch.py
+++ b/autoware_iv_internal_api_adaptor/launch/namespace.launch.py
@@ -1,10 +1,12 @@
 from launch import LaunchDescription
-from launch.actions import SetLaunchConfiguration
 from launch.actions import OpaqueFunction
+from launch.actions import SetLaunchConfiguration
+
 
 def current_ros_namespace(context):
     namespace = context.launch_configurations.get("ros_namespace", "")
     return [SetLaunchConfiguration("current_ros_namespace", namespace)]
+
 
 def generate_launch_description():
     return LaunchDescription([OpaqueFunction(function=current_ros_namespace)])

--- a/tier4_autoware_api_extension/launch/namespace.launch.py
+++ b/tier4_autoware_api_extension/launch/namespace.launch.py
@@ -1,0 +1,10 @@
+from launch import LaunchDescription
+from launch.actions import SetLaunchConfiguration
+from launch.actions import OpaqueFunction
+
+def current_ros_namespace(context):
+    namespace = context.launch_configurations.get("ros_namespace", "")
+    return [SetLaunchConfiguration("current_ros_namespace", namespace)]
+
+def generate_launch_description():
+    return LaunchDescription([OpaqueFunction(function=current_ros_namespace)])

--- a/tier4_autoware_api_extension/launch/namespace.launch.py
+++ b/tier4_autoware_api_extension/launch/namespace.launch.py
@@ -1,10 +1,12 @@
 from launch import LaunchDescription
-from launch.actions import SetLaunchConfiguration
 from launch.actions import OpaqueFunction
+from launch.actions import SetLaunchConfiguration
+
 
 def current_ros_namespace(context):
     namespace = context.launch_configurations.get("ros_namespace", "")
     return [SetLaunchConfiguration("current_ros_namespace", namespace)]
+
 
 def generate_launch_description():
     return LaunchDescription([OpaqueFunction(function=current_ros_namespace)])

--- a/tier4_autoware_api_extension/launch/tier4_autoware_api_extension.launch.xml
+++ b/tier4_autoware_api_extension/launch/tier4_autoware_api_extension.launch.xml
@@ -1,32 +1,28 @@
 <launch>
-  <!-- Nodes in this package. -->
   <group>
     <push-ros-namespace namespace="tier4_api"/>
-    <node pkg="tier4_autoware_api_extension" exec="route_distance_node"/>
-    <node pkg="tier4_autoware_api_extension" exec="traffic_light_node"/>
-    <node pkg="tier4_autoware_api_extension" exec="planning_factor_node">
-      <param from="$(find-pkg-share tier4_autoware_api_extension)/config/planning_factors.param.yaml"/>
-    </node>
-  </group>
-
-  <!-- Relay for tier4_v2x_msgs. -->
-  <group>
-    <push-ros-namespace namespace="tier4_api"/>
-    <node pkg="topic_tools" exec="relay" name="relay_virtual_traffic_light_status">
-      <param name="input_topic" value="/api/external/set/virtual_traffic_light/states"/>
-      <param name="output_topic" value="/awapi/tmp/virtual_traffic_light_states"/>
-      <param name="type" value="tier4_v2x_msgs/msg/VirtualTrafficLightStateArray"/>
-    </node>
-    <node pkg="topic_tools" exec="relay" name="relay_virtual_traffic_light_commands">
-      <param name="input_topic" value="/planning/scenario_planning/status/infrastructure_commands"/>
-      <param name="output_topic" value="/api/external/get/virtual_traffic_light/commands"/>
-      <param name="type" value="tier4_v2x_msgs/msg/InfrastructureCommandArray"/>
-    </node>
-  </group>
-
-  <!-- For route distance. -->
-  <group>
-    <push-ros-namespace namespace="tier4_api/utils"/>
-    <include file="$(find-pkg-share autoware_path_distance_calculator)/launch/path_distance_calculator.launch.xml"/>
+    <node_container pkg="rclcpp_components" exec="component_container" name="api_extension_container" namespace="">
+      <composable_node pkg="tier4_autoware_api_extension" plugin="tier4_autoware_api_extension::RouteDistance" name="route_distance"/>
+      <composable_node pkg="tier4_autoware_api_extension" plugin="tier4_autoware_api_extension::TrafficLight" name="traffic_light"/>
+      <composable_node pkg="tier4_autoware_api_extension" plugin="tier4_autoware_api_extension::PlanningFactor" name="planning_factor">
+        <param from="$(find-pkg-share tier4_autoware_api_extension)/config/planning_factors.param.yaml"/>
+      </composable_node>
+      <!-- Relay for tier4_v2x_msgs. -->
+      <composable_node pkg="topic_tools" plugin="topic_tools::RelayNode" name="relay_virtual_traffic_light_status">
+        <param name="input_topic" value="/api/external/set/virtual_traffic_light/states"/>
+        <param name="output_topic" value="/awapi/tmp/virtual_traffic_light_states"/>
+        <param name="type" value="tier4_v2x_msgs/msg/VirtualTrafficLightStateArray"/>
+      </composable_node>
+      <composable_node pkg="topic_tools" plugin="topic_tools::RelayNode" name="relay_virtual_traffic_light_commands">
+        <param name="input_topic" value="/planning/scenario_planning/status/infrastructure_commands"/>
+        <param name="output_topic" value="/api/external/get/virtual_traffic_light/commands"/>
+        <param name="type" value="tier4_v2x_msgs/msg/InfrastructureCommandArray"/>
+      </composable_node>
+      <!-- For route distance. -->
+      <composable_node pkg="autoware_path_distance_calculator" plugin="autoware::path_distance_calculator::PathDistanceCalculator" name="path_distance_calculator" namespace="utils">
+        <remap from="~/input/path" to="/planning/scenario_planning/lane_driving/behavior_planning/path"/>
+        <remap from="~/output/distance" to="~/distance"/>
+      </composable_node>
+    </node_container>
   </group>
 </launch>

--- a/tier4_autoware_api_extension/launch/tier4_autoware_api_extension.launch.xml
+++ b/tier4_autoware_api_extension/launch/tier4_autoware_api_extension.launch.xml
@@ -1,7 +1,10 @@
 <launch>
   <group>
     <push-ros-namespace namespace="tier4_api"/>
-    <node_container pkg="rclcpp_components" exec="component_container" name="api_extension_container" namespace="">
+    <node_container pkg="rclcpp_components" exec="component_container" name="api_extension_container" namespace=""/>
+
+    <include file="$(find-pkg-share tier4_autoware_api_extension)/launch/namespace.launch.py"/>
+    <load_composable_node target="$(var current_ros_namespace)/api_extension_container">
       <composable_node pkg="tier4_autoware_api_extension" plugin="tier4_autoware_api_extension::RouteDistance" name="route_distance"/>
       <composable_node pkg="tier4_autoware_api_extension" plugin="tier4_autoware_api_extension::TrafficLight" name="traffic_light"/>
       <composable_node pkg="tier4_autoware_api_extension" plugin="tier4_autoware_api_extension::PlanningFactor" name="planning_factor">
@@ -23,6 +26,6 @@
         <remap from="~/input/path" to="/planning/scenario_planning/lane_driving/behavior_planning/path"/>
         <remap from="~/output/distance" to="~/distance"/>
       </composable_node>
-    </node_container>
+    </load_composable_node>
   </group>
 </launch>

--- a/tier4_deprecated_api_adapter/launch/namespace.launch.py
+++ b/tier4_deprecated_api_adapter/launch/namespace.launch.py
@@ -1,0 +1,10 @@
+from launch import LaunchDescription
+from launch.actions import SetLaunchConfiguration
+from launch.actions import OpaqueFunction
+
+def current_ros_namespace(context):
+    namespace = context.launch_configurations.get("ros_namespace", "")
+    return [SetLaunchConfiguration("current_ros_namespace", namespace)]
+
+def generate_launch_description():
+    return LaunchDescription([OpaqueFunction(function=current_ros_namespace)])

--- a/tier4_deprecated_api_adapter/launch/namespace.launch.py
+++ b/tier4_deprecated_api_adapter/launch/namespace.launch.py
@@ -1,10 +1,12 @@
 from launch import LaunchDescription
-from launch.actions import SetLaunchConfiguration
 from launch.actions import OpaqueFunction
+from launch.actions import SetLaunchConfiguration
+
 
 def current_ros_namespace(context):
     namespace = context.launch_configurations.get("ros_namespace", "")
     return [SetLaunchConfiguration("current_ros_namespace", namespace)]
+
 
 def generate_launch_description():
     return LaunchDescription([OpaqueFunction(function=current_ros_namespace)])

--- a/tier4_deprecated_api_adapter/launch/tier4_deprecated_api_adapter.launch.xml
+++ b/tier4_deprecated_api_adapter/launch/tier4_deprecated_api_adapter.launch.xml
@@ -13,12 +13,11 @@
       <composable_node pkg="tier4_deprecated_api_adapter" plugin="tier4_deprecated_api_adapter::ManualControl" name="remote" namespace="manual">
         <param name="mode" value="remote"/>
       </composable_node>
+      <composable_node pkg="topic_tools" plugin="topic_tools::RelayNode" name="relay_route_distance">
+        <param name="input_topic" value="/tier4_api/utils/path_distance_calculator/distance"/>
+        <param name="output_topic" value="/autoware_api/utils/path_distance_calculator/distance"/>
+        <param name="type" value="autoware_internal_debug_msgs/msg/Float64Stamped"/>
+      </composable_node>
     </load_composable_node>
-
-    <node pkg="topic_tools" exec="relay" name="relay_route_distance">
-      <param name="input_topic" value="/tier4_api/utils/path_distance_calculator/distance"/>
-      <param name="output_topic" value="/autoware_api/utils/path_distance_calculator/distance"/>
-      <param name="type" value="autoware_internal_debug_msgs/msg/Float64Stamped"/>
-    </node>
   </group>
 </launch>

--- a/tier4_deprecated_api_adapter/launch/tier4_deprecated_api_adapter.launch.xml
+++ b/tier4_deprecated_api_adapter/launch/tier4_deprecated_api_adapter.launch.xml
@@ -1,17 +1,15 @@
 <launch>
   <group>
     <push-ros-namespace namespace="tier4_api"/>
-    <node pkg="tier4_deprecated_api_adapter" exec="autoware_engage_node" name="engage"/>
-
-    <group>
-      <push-ros-namespace namespace="manual"/>
-      <node pkg="tier4_deprecated_api_adapter" exec="manual_status_node" name="status"/>
-      <node pkg="tier4_deprecated_api_adapter" exec="manual_control_node" name="local">
+    <node_container pkg="rclcpp_components" exec="component_container" name="deprecated_api_container" namespace="">
+      <composable_node pkg="tier4_deprecated_api_adapter" plugin="tier4_deprecated_api_adapter::AutowareEngage" name="engage"/>
+      <composable_node pkg="tier4_deprecated_api_adapter" plugin="tier4_deprecated_api_adapter::ManualStatus" name="status" namespace="manual"/>
+      <composable_node pkg="tier4_deprecated_api_adapter" plugin="tier4_deprecated_api_adapter::ManualControl" name="local" namespace="manual">
         <param name="mode" value="local"/>
-      </node>
-      <node pkg="tier4_deprecated_api_adapter" exec="manual_control_node" name="remote">
+      </composable_node>
+      <composable_node pkg="tier4_deprecated_api_adapter" plugin="tier4_deprecated_api_adapter::ManualControl" name="remote" namespace="manual">
         <param name="mode" value="remote"/>
-      </node>
-    </group>
+      </composable_node>
+    </node_container>
   </group>
 </launch>

--- a/tier4_deprecated_api_adapter/launch/tier4_deprecated_api_adapter.launch.xml
+++ b/tier4_deprecated_api_adapter/launch/tier4_deprecated_api_adapter.launch.xml
@@ -1,7 +1,10 @@
 <launch>
   <group>
     <push-ros-namespace namespace="tier4_api"/>
-    <node_container pkg="rclcpp_components" exec="component_container" name="deprecated_api_container" namespace="">
+    <node_container pkg="rclcpp_components" exec="component_container" name="deprecated_api_container" namespace=""/>
+
+    <include file="$(find-pkg-share tier4_deprecated_api_adapter)/launch/namespace.launch.py"/>
+    <load_composable_node target="$(var current_ros_namespace)/deprecated_api_container">
       <composable_node pkg="tier4_deprecated_api_adapter" plugin="tier4_deprecated_api_adapter::AutowareEngage" name="engage"/>
       <composable_node pkg="tier4_deprecated_api_adapter" plugin="tier4_deprecated_api_adapter::ManualStatus" name="status" namespace="manual"/>
       <composable_node pkg="tier4_deprecated_api_adapter" plugin="tier4_deprecated_api_adapter::ManualControl" name="local" namespace="manual">
@@ -10,6 +13,6 @@
       <composable_node pkg="tier4_deprecated_api_adapter" plugin="tier4_deprecated_api_adapter::ManualControl" name="remote" namespace="manual">
         <param name="mode" value="remote"/>
       </composable_node>
-    </node_container>
+    </load_composable_node>
   </group>
 </launch>


### PR DESCRIPTION
## Background
One cause of Pilot.Auto's long startup time is the exponential increase in discovery traffic due to the large number of ROS2 processes.
We are working to address this by reducing the process count through loading nodes into component containers.
https://star4.slack.com/archives/CTEJP8L4T/p1761906077877939

## Changes
Relevant nodes are now launched as composable nodes.

## Test
The following script was run, and its output was compared before and after the change.

```sh
#!/usr/bin/env bash

echo "Starting to fetch info for active ROS 2 nodes..."
echo

for node in $(ros2 node list)
do
    if [[ "$node" == *transform_listener* ]]; then
        continue
    fi
    if [[ "$node" == *launch_ros* ]]; then
        continue

    echo "##################################################"
    echo "## Node Info: $node"
    echo "##################################################"

    ros2 node info "$node"
    
    echo 
done

echo "All node info retrieved."
```

The result shows that the added container nodes are the only difference.

```sh
$ colordiff -u x2_v4_3_commit16-before_beta_v0.48.txt x2_v4_3_commit16_add_distance_relay_node.txt 
--- x2_v4_3_commit16-before_beta_v0.48.txt	2025-11-10 17:14:33.334412551 +0900
+++ x2_v4_3_commit16_add_distance_relay_node.txt	2025-11-10 17:04:16.300973703 +0900
@@ -1325,6 +1325,24 @@
 
 
 ##################################################
+## Node Info: /autoware_api/internal/internal_api_relay_container
+##################################################
+/autoware_api/internal/internal_api_relay_container
+  Subscribers:
+    /clock: rosgraph_msgs/msg/Clock
+    /parameter_events: rcl_interfaces/msg/ParameterEvent
+  Publishers:
+    /rosout: rcl_interfaces/msg/Log
+  Service Servers:
+
+  Service Clients:
+
+  Action Servers:
+
+  Action Clients:
+
+
+##################################################
 ## Node Info: /autoware_api/internal/intersection_states
 ##################################################
 /autoware_api/internal/intersection_states
@@ -8470,6 +8488,42 @@
   Service Clients:
 
   Action Servers:
+
+  Action Clients:
+
+
+##################################################
+## Node Info: /tier4_api/api_extension_container
+##################################################
+/tier4_api/api_extension_container
+  Subscribers:
+    /clock: rosgraph_msgs/msg/Clock
+    /parameter_events: rcl_interfaces/msg/ParameterEvent
+  Publishers:
+    /rosout: rcl_interfaces/msg/Log
+  Service Servers:
+
+  Service Clients:
+
+  Action Servers:
+
+  Action Clients:
+
+
+##################################################
+## Node Info: /tier4_api/deprecated_api_container
+##################################################
+/tier4_api/deprecated_api_container
+  Subscribers:
+    /clock: rosgraph_msgs/msg/Clock
+    /parameter_events: rcl_interfaces/msg/ParameterEvent
+  Publishers:
+    /rosout: rcl_interfaces/msg/Log
+  Service Servers:
+
+  Service Clients:
+
+  Action Servers:
 
   Action Clients:
****
```