### PR TITLE
feat: refactor launch files to use composable nodes and add scripts to handle namespace (fixed)

### DIFF
--- a/autoware_iv_internal_api_adaptor/launch/internal_api_relay.launch.xml
+++ b/autoware_iv_internal_api_adaptor/launch/internal_api_relay.launch.xml
@@ -1,20 +1,25 @@
 <launch>
   <group>
     <push-ros-namespace namespace="internal"/>
-    <node pkg="topic_tools" exec="relay" name="traffic_signals">
-      <param name="input_topic" value="/api/autoware/set/traffic_signals"/>
-      <param name="output_topic" value="/external/traffic_light_recognition/traffic_signals"/>
-      <param name="type" value="autoware_perception_msgs/msg/TrafficSignalArray"/>
-    </node>
-    <node pkg="topic_tools" exec="relay" name="intersection_states">
-      <param name="input_topic" value="/api/autoware/set/intersection_states"/>
-      <param name="output_topic" value="/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/input/external_intersection_states"/>
-      <param name="type" value="tier4_api_msgs/msg/IntersectionStatus"/>
-    </node>
-    <node pkg="topic_tools" exec="relay" name="crosswalk_states">
-      <param name="input_topic" value="/api/autoware/set/crosswalk_states"/>
-      <param name="output_topic" value="/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/input/external_crosswalk_states"/>
-      <param name="type" value="tier4_api_msgs/msg/CrosswalkStatus"/>
-    </node>
+    <node_container pkg="rclcpp_components" exec="component_container" name="internal_api_relay_container" namespace=""/>
+
+    <include file="$(find-pkg-share autoware_iv_internal_api_adaptor)/launch/namespace.launch.py"/>
+    <load_composable_node target="$(var current_ros_namespace)/internal_api_relay_container">
+      <composable_node pkg="topic_tools" plugin="topic_tools::RelayNode" name="traffic_signals">
+        <param name="input_topic" value="/api/autoware/set/traffic_signals"/>
+        <param name="output_topic" value="/external/traffic_light_recognition/traffic_signals"/>
+        <param name="type" value="autoware_perception_msgs/msg/TrafficSignalArray"/>
+      </composable_node>
+      <composable_node pkg="topic_tools" plugin="topic_tools::RelayNode" name="intersection_states">
+        <param name="input_topic" value="/api/autoware/set/intersection_states"/>
+        <param name="output_topic" value="/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/input/external_intersection_states"/>
+        <param name="type" value="tier4_api_msgs/msg/IntersectionStatus"/>
+      </composable_node>
+      <composable_node pkg="topic_tools" plugin="topic_tools::RelayNode" name="crosswalk_states">
+        <param name="input_topic" value="/api/autoware/set/crosswalk_states"/>
+        <param name="output_topic" value="/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/input/external_crosswalk_states"/>
+        <param name="type" value="tier4_api_msgs/msg/CrosswalkStatus"/>
+      </composable_node>
+    </load_composable_node>
   </group>
 </launch>

--- a/autoware_iv_internal_api_adaptor/launch/internal_api_relay.launch.xml
+++ b/autoware_iv_internal_api_adaptor/launch/internal_api_relay.launch.xml
@@ -1,7 +1,7 @@
 <launch>
   <group>
     <push-ros-namespace namespace="internal"/>
-    <node_container pkg="rclcpp_components" exec="component_container" name="internal_api_relay_container" namespace=""/>
+    <node_container pkg="rclcpp_components" exec="component_container_mt" name="internal_api_relay_container" namespace=""/>
 
     <include file="$(find-pkg-share autoware_iv_internal_api_adaptor)/launch/namespace.launch.py"/>
     <load_composable_node target="$(var current_ros_namespace)/internal_api_relay_container">

--- a/autoware_iv_internal_api_adaptor/launch/namespace.launch.py
+++ b/autoware_iv_internal_api_adaptor/launch/namespace.launch.py
@@ -1,0 +1,26 @@
+# Copyright 2025 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchDescription
+from launch.actions import OpaqueFunction
+from launch.actions import SetLaunchConfiguration
+
+
+def current_ros_namespace(context):
+    namespace = context.launch_configurations.get("ros_namespace", "")
+    return [SetLaunchConfiguration("current_ros_namespace", namespace)]
+
+
+def generate_launch_description():
+    return LaunchDescription([OpaqueFunction(function=current_ros_namespace)])

--- a/tier4_autoware_api_extension/launch/namespace.launch.py
+++ b/tier4_autoware_api_extension/launch/namespace.launch.py
@@ -1,0 +1,26 @@
+# Copyright 2025 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchDescription
+from launch.actions import OpaqueFunction
+from launch.actions import SetLaunchConfiguration
+
+
+def current_ros_namespace(context):
+    namespace = context.launch_configurations.get("ros_namespace", "")
+    return [SetLaunchConfiguration("current_ros_namespace", namespace)]
+
+
+def generate_launch_description():
+    return LaunchDescription([OpaqueFunction(function=current_ros_namespace)])

--- a/tier4_autoware_api_extension/launch/tier4_autoware_api_extension.launch.xml
+++ b/tier4_autoware_api_extension/launch/tier4_autoware_api_extension.launch.xml
@@ -1,40 +1,61 @@
 <launch>
   <arg name="api_mode" default="0" description="options: 0(All), 1(Without 2025/09 EOL API), 2(Without 2025/12 EOL API)"/>
 
+  <!-- Component Container -->
+  <group>
+    <push-ros-namespace namespace="tier4_api"/>
+    <node_container pkg="rclcpp_components" exec="component_container" name="api_extension_container" namespace=""/>
+  </group>
+
   <!-- Nodes in this package. -->
   <group>
     <push-ros-namespace namespace="tier4_api"/>
-    <node pkg="tier4_autoware_api_extension" exec="route_distance_node"/>
-    <node pkg="tier4_autoware_api_extension" exec="traffic_light_node"/>
-    <node pkg="tier4_autoware_api_extension" exec="planning_factor_node">
-      <param from="$(find-pkg-share tier4_autoware_api_extension)/config/planning_factors.param.yaml"/>
-    </node>
+    <include file="$(find-pkg-share tier4_autoware_api_extension)/launch/namespace.launch.py"/>
+    <load_composable_node target="$(var current_ros_namespace)/api_extension_container">
+      <composable_node pkg="tier4_autoware_api_extension" plugin="tier4_autoware_api_extension::RouteDistance" name="route_distance"/>
+      <composable_node pkg="tier4_autoware_api_extension" plugin="tier4_autoware_api_extension::TrafficLight" name="traffic_light"/>
+      <composable_node pkg="tier4_autoware_api_extension" plugin="tier4_autoware_api_extension::PlanningFactor" name="planning_factor">
+        <param from="$(find-pkg-share tier4_autoware_api_extension)/config/planning_factors.param.yaml"/>
+      </composable_node>
+    </load_composable_node>
   </group>
 
   <!-- Nodes in this package. Switch for 2025/12 EOL API. -->
   <group unless="$(eval &quot; $(var api_mode) &lt; 2 &quot;)">
     <push-ros-namespace namespace="tier4_api"/>
-    <node pkg="tier4_autoware_api_extension" exec="velocity_limit_node"/>
+    <include file="$(find-pkg-share tier4_autoware_api_extension)/launch/namespace.launch.py"/>
+    <load_composable_node target="$(var current_ros_namespace)/api_extension_container">
+      <composable_node pkg="tier4_autoware_api_extension" plugin="tier4_autoware_api_extension::VelocityLimit" name="velocity_limit"/>
+    </load_composable_node>
   </group>
 
   <!-- Relay for tier4_v2x_msgs. -->
   <group>
     <push-ros-namespace namespace="tier4_api"/>
-    <node pkg="topic_tools" exec="relay" name="relay_virtual_traffic_light_status">
-      <param name="input_topic" value="/api/external/set/virtual_traffic_light/states"/>
-      <param name="output_topic" value="/awapi/tmp/virtual_traffic_light_states"/>
-      <param name="type" value="tier4_v2x_msgs/msg/VirtualTrafficLightStateArray"/>
-    </node>
-    <node pkg="topic_tools" exec="relay" name="relay_virtual_traffic_light_commands">
-      <param name="input_topic" value="/planning/scenario_planning/status/infrastructure_commands"/>
-      <param name="output_topic" value="/api/external/get/virtual_traffic_light/commands"/>
-      <param name="type" value="tier4_v2x_msgs/msg/InfrastructureCommandArray"/>
-    </node>
+    <include file="$(find-pkg-share tier4_autoware_api_extension)/launch/namespace.launch.py"/>
+    <load_composable_node target="$(var current_ros_namespace)/api_extension_container">
+      <composable_node pkg="topic_tools" plugin="topic_tools::RelayNode" name="relay_virtual_traffic_light_status">
+        <param name="input_topic" value="/api/external/set/virtual_traffic_light/states"/>
+        <param name="output_topic" value="/awapi/tmp/virtual_traffic_light_states"/>
+        <param name="type" value="tier4_v2x_msgs/msg/VirtualTrafficLightStateArray"/>
+      </composable_node>
+      <composable_node pkg="topic_tools" plugin="topic_tools::RelayNode" name="relay_virtual_traffic_light_commands">
+        <param name="input_topic" value="/planning/scenario_planning/status/infrastructure_commands"/>
+        <param name="output_topic" value="/api/external/get/virtual_traffic_light/commands"/>
+        <param name="type" value="tier4_v2x_msgs/msg/InfrastructureCommandArray"/>
+      </composable_node>
+    </load_composable_node>
   </group>
 
   <!-- For route distance. -->
   <group>
-    <push-ros-namespace namespace="tier4_api/utils"/>
-    <include file="$(find-pkg-share autoware_path_distance_calculator)/launch/path_distance_calculator.launch.xml"/>
+    <push-ros-namespace namespace="tier4_api"/>
+    <include file="$(find-pkg-share tier4_autoware_api_extension)/launch/namespace.launch.py"/>
+    <load_composable_node target="$(var current_ros_namespace)/api_extension_container">
+      <composable_node pkg="autoware_path_distance_calculator" plugin="autoware::path_distance_calculator::PathDistanceCalculator" name="path_distance_calculator" namespace="utils">
+        <remap from="~/input/path" to="/planning/scenario_planning/lane_driving/behavior_planning/path"/>
+        <remap from="~/output/distance" to="~/distance"/>
+      </composable_node>
+    </load_composable_node>
   </group>
 </launch>

--- a/tier4_autoware_api_extension/launch/tier4_autoware_api_extension.launch.xml
+++ b/tier4_autoware_api_extension/launch/tier4_autoware_api_extension.launch.xml
@@ -4,7 +4,7 @@
   <!-- Component Container -->
   <group>
     <push-ros-namespace namespace="tier4_api"/>
-    <node_container pkg="rclcpp_components" exec="component_container" name="api_extension_container" namespace=""/>
+    <node_container pkg="rclcpp_components" exec="component_container_mt" name="api_extension_container" namespace=""/>
   </group>
 
   <!-- Nodes in this package. -->

--- a/tier4_deprecated_api_adapter/launch/namespace.launch.py
+++ b/tier4_deprecated_api_adapter/launch/namespace.launch.py
@@ -1,0 +1,26 @@
+# Copyright 2025 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchDescription
+from launch.actions import OpaqueFunction
+from launch.actions import SetLaunchConfiguration
+
+
+def current_ros_namespace(context):
+    namespace = context.launch_configurations.get("ros_namespace", "")
+    return [SetLaunchConfiguration("current_ros_namespace", namespace)]
+
+
+def generate_launch_description():
+    return LaunchDescription([OpaqueFunction(function=current_ros_namespace)])

--- a/tier4_deprecated_api_adapter/launch/tier4_deprecated_api_adapter.launch.xml
+++ b/tier4_deprecated_api_adapter/launch/tier4_deprecated_api_adapter.launch.xml
@@ -1,7 +1,7 @@
 <launch>
   <group>
     <push-ros-namespace namespace="tier4_api"/>
-    <node_container pkg="rclcpp_components" exec="component_container" name="deprecated_api_container" namespace=""/>
+    <node_container pkg="rclcpp_components" exec="component_container_mt" name="deprecated_api_container" namespace=""/>
 
     <include file="$(find-pkg-share tier4_deprecated_api_adapter)/launch/namespace.launch.py"/>
     <load_composable_node target="$(var current_ros_namespace)/deprecated_api_container">

--- a/tier4_deprecated_api_adapter/launch/tier4_deprecated_api_adapter.launch.xml
+++ b/tier4_deprecated_api_adapter/launch/tier4_deprecated_api_adapter.launch.xml
@@ -1,23 +1,23 @@
 <launch>
   <group>
     <push-ros-namespace namespace="tier4_api"/>
-    <node pkg="tier4_deprecated_api_adapter" exec="autoware_engage_node" name="engage"/>
+    <node_container pkg="rclcpp_components" exec="component_container" name="deprecated_api_container" namespace=""/>
 
-    <group>
-      <push-ros-namespace namespace="manual"/>
-      <node pkg="tier4_deprecated_api_adapter" exec="manual_status_node" name="status"/>
-      <node pkg="tier4_deprecated_api_adapter" exec="manual_control_node" name="local">
+    <include file="$(find-pkg-share tier4_deprecated_api_adapter)/launch/namespace.launch.py"/>
+    <load_composable_node target="$(var current_ros_namespace)/deprecated_api_container">
+      <composable_node pkg="tier4_deprecated_api_adapter" plugin="tier4_deprecated_api_adapter::AutowareEngage" name="engage"/>
+      <composable_node pkg="tier4_deprecated_api_adapter" plugin="tier4_deprecated_api_adapter::ManualStatus" name="status" namespace="manual"/>
+      <composable_node pkg="tier4_deprecated_api_adapter" plugin="tier4_deprecated_api_adapter::ManualControl" name="local" namespace="manual">
         <param name="mode" value="local"/>
-      </node>
-      <node pkg="tier4_deprecated_api_adapter" exec="manual_control_node" name="remote">
+      </composable_node>
+      <composable_node pkg="tier4_deprecated_api_adapter" plugin="tier4_deprecated_api_adapter::ManualControl" name="remote" namespace="manual">
         <param name="mode" value="remote"/>
-      </node>
-    </group>
-
-    <node pkg="topic_tools" exec="relay" name="relay_route_distance">
-      <param name="input_topic" value="/tier4_api/utils/path_distance_calculator/distance"/>
-      <param name="output_topic" value="/autoware_api/utils/path_distance_calculator/distance"/>
-      <param name="type" value="autoware_internal_debug_msgs/msg/Float64Stamped"/>
-    </node>
+      </composable_node>
+      <composable_node pkg="topic_tools" plugin="topic_tools::RelayNode" name="relay_route_distance">
+        <param name="input_topic" value="/tier4_api/utils/path_distance_calculator/distance"/>
+        <param name="output_topic" value="/autoware_api/utils/path_distance_calculator/distance"/>
+        <param name="type" value="autoware_internal_debug_msgs/msg/Float64Stamped"/>
+      </composable_node>
+    </load_composable_node>
   </group>
 </launch>


### PR DESCRIPTION
## Background 
In a previous PR, api nodes were launched as composable nodes.
https://github.com/tier4/tier4_ad_api_adaptor/pull/183

However, this PR caused a failure in the scenario test.
https://star4.slack.com/archives/C04HK9T2E0N/p1762995641893309?thread_ts=1762978453.117699&cid=C04HK9T2E0N

This was because `/api/set/engage` is a relayed service and it does not work in a single thread if the relayed service is also working in the same thread.

Therefore, that PR was reverted.

## Changes
- Re-introduce https://github.com/tier4/tier4_ad_api_adaptor/pull/183
- Change the component container to be multi-threaded. See 802cde2ca1f4d2d305a4157e51ce1f32cb9b0eef
- 
## Test
I have checked that a vehicle did not move with the previous PR but does move with this PR, using the following command.
```sh
~/pilot.auto$ webauto ci scenario run --project-id prd_jt --scenario-id f42623a2-28ac-4a5c-bd23-a24b0ac4160a --scenario-version-id 5 --simulation-name planning_sim_v2
```