### PR TITLE
feat(tier4_deprecated_api_adapter): add initial pose relay

### DIFF
--- a/tier4_deprecated_api_adapter/CMakeLists.txt
+++ b/tier4_deprecated_api_adapter/CMakeLists.txt
@@ -11,6 +11,10 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/manual_status.cpp
 )
 
+rclcpp_components_register_nodes(${PROJECT_NAME}
+  "tier4_deprecated_api_adapter::InitialPose"
+)
+
 rclcpp_components_register_node(${PROJECT_NAME}
   PLUGIN "tier4_deprecated_api_adapter::AutowareEngage"
   EXECUTABLE autoware_engage_node

--- a/tier4_deprecated_api_adapter/CMakeLists.txt
+++ b/tier4_deprecated_api_adapter/CMakeLists.txt
@@ -6,6 +6,7 @@ autoware_package()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/autoware_engage.cpp
+  src/initial_pose.cpp
   src/manual_control.cpp
   src/manual_status.cpp
 )

--- a/tier4_deprecated_api_adapter/launch/tier4_deprecated_api_adapter.launch.xml
+++ b/tier4_deprecated_api_adapter/launch/tier4_deprecated_api_adapter.launch.xml
@@ -1,10 +1,12 @@
 <launch>
+  <arg name="api_mode" default="0" description="options: 0(All), 1(Without 2025/09 EOL API), 2(Without 2025/12 EOL API)"/>
+
   <group>
     <push-ros-namespace namespace="tier4_api"/>
     <node_container pkg="rclcpp_components" exec="component_container_mt" name="deprecated_api_container" namespace=""/>
-
     <include file="$(find-pkg-share tier4_deprecated_api_adapter)/launch/namespace.launch.py"/>
-    <load_composable_node target="$(var current_ros_namespace)/deprecated_api_container">
+
+    <load_composable_node target="$(var current_ros_namespace)/deprecated_api_container" if="$(eval &quot; $(var api_mode) &lt; 2 &quot;)">
       <composable_node pkg="tier4_deprecated_api_adapter" plugin="tier4_deprecated_api_adapter::AutowareEngage" name="engage"/>
       <composable_node pkg="tier4_deprecated_api_adapter" plugin="tier4_deprecated_api_adapter::ManualStatus" name="status" namespace="manual"/>
       <composable_node pkg="tier4_deprecated_api_adapter" plugin="tier4_deprecated_api_adapter::ManualControl" name="local" namespace="manual">
@@ -18,6 +20,10 @@
         <param name="output_topic" value="/autoware_api/utils/path_distance_calculator/distance"/>
         <param name="type" value="autoware_internal_debug_msgs/msg/Float64Stamped"/>
       </composable_node>
+    </load_composable_node>
+
+    <load_composable_node target="$(var current_ros_namespace)/deprecated_api_container" unless="$(eval &quot; $(var api_mode) &lt; 2 &quot;)">
+      <composable_node pkg="tier4_deprecated_api_adapter" plugin="tier4_deprecated_api_adapter::InitialPose" name="initial_pose"/>
     </load_composable_node>
   </group>
 </launch>

--- a/tier4_deprecated_api_adapter/launch/tier4_deprecated_api_adapter.launch.xml
+++ b/tier4_deprecated_api_adapter/launch/tier4_deprecated_api_adapter.launch.xml
@@ -6,6 +6,7 @@
     <node_container pkg="rclcpp_components" exec="component_container_mt" name="deprecated_api_container" namespace=""/>
     <include file="$(find-pkg-share tier4_deprecated_api_adapter)/launch/namespace.launch.py"/>
 
+    <!-- 2025/12 EOL API, launch if api_mode < 2 -->
     <load_composable_node target="$(var current_ros_namespace)/deprecated_api_container" if="$(eval &quot; $(var api_mode) &lt; 2 &quot;)">
       <composable_node pkg="tier4_deprecated_api_adapter" plugin="tier4_deprecated_api_adapter::AutowareEngage" name="engage"/>
       <composable_node pkg="tier4_deprecated_api_adapter" plugin="tier4_deprecated_api_adapter::ManualStatus" name="status" namespace="manual"/>
@@ -22,6 +23,7 @@
       </composable_node>
     </load_composable_node>
 
+    <!-- 2026/09 EOL API, use external_api_adapter if < 2, else use this package -->
     <load_composable_node target="$(var current_ros_namespace)/deprecated_api_container" unless="$(eval &quot; $(var api_mode) &lt; 2 &quot;)">
       <composable_node pkg="tier4_deprecated_api_adapter" plugin="tier4_deprecated_api_adapter::InitialPose" name="initial_pose"/>
     </load_composable_node>

--- a/tier4_deprecated_api_adapter/launch/tier4_deprecated_api_adapter.launch.xml
+++ b/tier4_deprecated_api_adapter/launch/tier4_deprecated_api_adapter.launch.xml
@@ -23,7 +23,7 @@
       </composable_node>
     </load_composable_node>
 
-    <!-- 2026/09 EOL API, use external_api_adapter if < 2, else use this package -->
+    <!-- 2026/09 EOL API, use external_api_adapter if api_mode < 2, else use this package -->
     <load_composable_node target="$(var current_ros_namespace)/deprecated_api_container" unless="$(eval &quot; $(var api_mode) &lt; 2 &quot;)">
       <composable_node pkg="tier4_deprecated_api_adapter" plugin="tier4_deprecated_api_adapter::InitialPose" name="initial_pose"/>
     </load_composable_node>

--- a/tier4_deprecated_api_adapter/src/initial_pose.cpp
+++ b/tier4_deprecated_api_adapter/src/initial_pose.cpp
@@ -1,0 +1,70 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "initial_pose.hpp"
+
+#include "utils/response.hpp"
+
+#include <array>
+#include <memory>
+
+namespace tier4_deprecated_api_adapter
+{
+
+constexpr double initial_pose_timeout = 300;
+
+// clang-format off
+const std::array<double, 36> particle_covariance =
+{
+  1.00, 0.00, 0.00, 0.00, 0.00,  0.00,
+  0.00, 1.00, 0.00, 0.00, 0.00,  0.00,
+  0.00, 0.00, 0.01, 0.00, 0.00,  0.00,
+  0.00, 0.00, 0.00, 0.01, 0.00,  0.00,
+  0.00, 0.00, 0.00, 0.00, 0.01,  0.00,
+  0.00, 0.00, 0.00, 0.00, 0.00, 10.00,
+};
+// clang-format on
+
+InitialPose::InitialPose(const rclcpp::NodeOptions & options)
+: Node("external_api_initial_pose", options)
+{
+  using std::placeholders::_1;
+  using std::placeholders::_2;
+
+  srv_ = create_service<OldService>(
+    "/api/external/set/initialize_pose", std::bind(&InitialPose::on_service, this, _1, _2));
+  cli_ = create_client<NewService>("/api/localization/initialize");
+}
+
+void InitialPose::on_service(
+  const std::shared_ptr<rmw_request_id_t> header, const OldService::Request::SharedPtr request)
+{
+  const auto on_response = [this, header](rclcpp::Client<NewService>::SharedFuture future) {
+    const auto res = future.get();
+    const auto function = res->status.success ? utils::response_success : utils::response_error;
+    OldService::Response response;
+    response.status = function(res->status.message);
+    srv_->send_response(*header, response);
+  };
+
+  const auto req = std::make_shared<NewService::Request>();
+  req->pose.push_back(request->pose);
+  req->pose.back().pose.covariance = particle_covariance;
+  cli_->async_send_request(req, on_response);
+}
+
+}  // namespace tier4_deprecated_api_adapter
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(tier4_deprecated_api_adapter::InitialPose)

--- a/tier4_deprecated_api_adapter/src/initial_pose.cpp
+++ b/tier4_deprecated_api_adapter/src/initial_pose.cpp
@@ -18,11 +18,12 @@
 
 #include <array>
 #include <memory>
+#include <utility>
 
 namespace tier4_deprecated_api_adapter
 {
 
-constexpr double initial_pose_timeout = 300;
+constexpr std::chrono::seconds initial_pose_timeout = std::chrono::seconds(300);
 
 // clang-format off
 const std::array<double, 36> particle_covariance =
@@ -51,17 +52,35 @@ void InitialPose::on_service(
   const std::shared_ptr<rmw_request_id_t> header, const OldService::Request::SharedPtr request)
 {
   const auto on_response = [this, header](rclcpp::Client<NewService>::SharedFuture future) {
+    if (!timer_) return;  // The timer is reset when it is timed out.
+    timer_->cancel();
+    timer_.reset();
     const auto res = future.get();
     const auto function = res->status.success ? utils::response_success : utils::response_error;
     OldService::Response response;
     response.status = function(res->status.message);
-    srv_->send_response(*header, response);
+    return srv_->send_response(*header, response);
   };
+
+  const auto on_timeout = [this, header]() {
+    timer_->cancel();
+    timer_.reset();
+    OldService::Response response;
+    response.status = utils::response_error("Internal service has timed out.");
+    return srv_->send_response(*header, response);
+  };
+
+  if (!cli_->service_is_ready()) {
+    OldService::Response response;
+    response.status = utils::response_error("Internal service is not available.");
+    return srv_->send_response(*header, response);
+  }
 
   const auto req = std::make_shared<NewService::Request>();
   req->pose.push_back(request->pose);
   req->pose.back().pose.covariance = particle_covariance;
   cli_->async_send_request(req, on_response);
+  timer_ = rclcpp::create_timer(this, get_clock(), initial_pose_timeout, std::move(on_timeout));
 }
 
 }  // namespace tier4_deprecated_api_adapter

--- a/tier4_deprecated_api_adapter/src/initial_pose.hpp
+++ b/tier4_deprecated_api_adapter/src/initial_pose.hpp
@@ -34,7 +34,7 @@ private:
   using NewService = autoware_adapi_v1_msgs::srv::InitializeLocalization;
   using OldService = tier4_external_api_msgs::srv::InitializePose;
 
-  rclcpp::CallbackGroup::SharedPtr group_;
+  rclcpp::TimerBase::SharedPtr timer_;
   rclcpp::Service<OldService>::SharedPtr srv_;
   rclcpp::Client<NewService>::SharedPtr cli_;
 

--- a/tier4_deprecated_api_adapter/src/initial_pose.hpp
+++ b/tier4_deprecated_api_adapter/src/initial_pose.hpp
@@ -1,0 +1,47 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INITIAL_POSE_HPP_
+#define INITIAL_POSE_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_adapi_v1_msgs/srv/initialize_localization.hpp>
+#include <tier4_external_api_msgs/srv/initialize_pose.hpp>
+
+#include <memory>
+
+namespace tier4_deprecated_api_adapter
+{
+
+class InitialPose : public rclcpp::Node
+{
+public:
+  explicit InitialPose(const rclcpp::NodeOptions & options);
+
+private:
+  using NewService = autoware_adapi_v1_msgs::srv::InitializeLocalization;
+  using OldService = tier4_external_api_msgs::srv::InitializePose;
+
+  rclcpp::CallbackGroup::SharedPtr group_;
+  rclcpp::Service<OldService>::SharedPtr srv_;
+  rclcpp::Client<NewService>::SharedPtr cli_;
+
+  void on_service(
+    const std::shared_ptr<rmw_request_id_t> header, const OldService::Request::SharedPtr request);
+};
+
+}  // namespace tier4_deprecated_api_adapter
+
+#endif  // INITIAL_POSE_HPP_


### PR DESCRIPTION
## Description

Extends support for initial pose for rosbridge compatibility.
The new implementation uses ADAPI instead of calling the internal service directly.

## Related links

https://github.com/autowarefoundation/autoware_universe/pull/11687

## How was this PR tested?

1. Checkout https://github.com/autowarefoundation/autoware_universe/pull/11687
2. Launch planning simulation with launch_deprecated_api:=true api_mode:=2
3. Check that the vehicle pose is initialized by the following command

```
ros2 service call /api/external/set/initialize_pose tier4_external_api_msgs/srv/InitializePose "
pose:
  header:
    frame_id: map
  pose:
    pose:
      position:
        x: 3730.140869140625
        y: 73727.7734375
        z: 0.0
      orientation:
        x: 0.0
        y: 0.0
        z: 0.24019710926824225
        w: 0.970724136250449
"
```