### PR TITLE
feat: add CreepGuidanceController and related module for managing creep guidance

### DIFF
--- a/autoware_iv_external_api_adaptor/CMakeLists.txt
+++ b/autoware_iv_external_api_adaptor/CMakeLists.txt
@@ -7,6 +7,7 @@ autoware_package()
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/calibration_status.cpp
   src/cpu_usage.cpp
+  src/creep_guidance_controller.cpp
   src/diagnostics.cpp
   src/door.cpp
   src/emergency.cpp
@@ -31,6 +32,7 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 rclcpp_components_register_nodes(${PROJECT_NAME}
   "external_api::CalibrationStatus"
   "external_api::CpuUsage"
+  "external_api::CreepGuidanceController"
   "external_api::Diagnostics"
   "external_api::Door"
   "external_api::Emergency"

--- a/autoware_iv_external_api_adaptor/package.xml
+++ b/autoware_iv_external_api_adaptor/package.xml
@@ -25,6 +25,7 @@
   <depend>tier4_api_msgs</depend>
   <depend>tier4_api_utils</depend>
   <depend>tier4_auto_msgs_converter</depend>
+  <depend>tier4_creep_guidance_msgs</depend>
   <depend>tier4_external_api_msgs</depend>
   <depend>tier4_rtc_msgs</depend>
   <depend>tier4_vehicle_msgs</depend>

--- a/autoware_iv_external_api_adaptor/src/creep_guidance_controller.cpp
+++ b/autoware_iv_external_api_adaptor/src/creep_guidance_controller.cpp
@@ -1,0 +1,178 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "creep_guidance_controller.hpp"
+
+#include <memory>
+
+namespace
+{
+// Temporary fix for ROS2 humble
+void check_inf_distance(CreepStatus & status)
+{
+  if (!std::isfinite(status.start_distance)) {
+    status.start_distance = -100000.0;
+  }
+  if (!std::isfinite(status.finish_distance)) {
+    status.finish_distance = -100000.0;
+  }
+}
+
+void align_creep_status_array(std::vector<CreepStatus> & statuses_vector)
+{
+  if (statuses_vector.empty()) {
+    return;
+  }
+  tier4_creep_guidance_msgs::msg::CreepStatus current_status;
+  check_inf_distance(statuses_vector[0]);
+  for (size_t i = 1; i < statuses_vector.size(); i++) {
+    check_inf_distance(statuses_vector[i]);
+    current_status = statuses_vector[i];
+    int j = i - 1;
+
+    while (j >= 0 && current_status.start_distance < statuses_vector[j].start_distance) {
+      statuses_vector[j + 1] = statuses_vector[j];
+      j = j - 1;
+    }
+    statuses_vector[j + 1] = current_status;
+  }
+}
+}  // namespace
+
+CreepGuidanceModule::CreepGuidanceModule(rclcpp::Node * node, const std::string & name)
+: logger_(node->get_logger())
+{
+  using namespace std::literals::chrono_literals;
+  using std::placeholders::_1;
+  tier4_api_utils::ServiceProxyNodeInterface proxy(node);
+
+  module_sub_ = node->create_subscription<CreepStatusArray>(
+    "/planning/creep_guidance_status/" + name, rclcpp::QoS(1),
+    std::bind(&CreepGuidanceModule::module_callback, this, _1));
+
+  // // Create a reentrant callback group for the service client to avoid deadlock
+  // client_callback_group_ =
+  //   node->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
+
+  cli_set_module_ = proxy.create_client<CreepTriggerCommandSrv>(
+    "/planning/creep_guidance_commands/" + name, rmw_qos_profile_services_default);
+}
+
+void CreepGuidanceModule::module_callback(const CreepStatusArray::ConstSharedPtr message)
+{
+  module_statuses_ = message->statuses;
+}
+
+void CreepGuidanceModule::insert_message(std::vector<CreepStatus> & creep_statuses)
+{
+  creep_statuses.insert(creep_statuses.end(), module_statuses_.begin(), module_statuses_.end());
+}
+
+void CreepGuidanceModule::call_service(
+  CreepTriggerCommandSrv::Request::SharedPtr request,
+  const CreepTriggerCommandSrv::Response::SharedPtr & responses)
+{
+  using namespace std::literals::chrono_literals;
+  // Increase timeout to 10 seconds to wait for server response
+  const auto [status, resp] = cli_set_module_->call(request);
+  if (!tier4_api_utils::is_success(status)) {
+    RCLCPP_ERROR(
+      logger_, "Failed to call service: %s (code: %d)", status.message.c_str(), status.code);
+    return;
+  }
+  responses->responses.insert(
+    responses->responses.end(), resp->responses.begin(), resp->responses.end());
+}
+
+namespace external_api
+{
+CreepGuidanceController::CreepGuidanceController(const rclcpp::NodeOptions & options)
+: Node("external_api_creep_guidance_controller", options)
+{
+  using namespace std::literals::chrono_literals;
+  using std::placeholders::_1;
+  using std::placeholders::_2;
+  tier4_api_utils::ServiceProxyNodeInterface proxy(this);
+
+  crosswalk_ = std::make_unique<CreepGuidanceModule>(this, "crosswalk");
+  intersection_ = std::make_unique<CreepGuidanceModule>(this, "intersection");
+  intersection_occlusion_ = std::make_unique<CreepGuidanceModule>(this, "intersection_occlusion");
+
+  creep_status_pub_ =
+    create_publisher<CreepStatusArray>("/api/external/get/creep_status", rclcpp::QoS(1));
+
+  group_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  srv_set_creep_trigger_ = proxy.create_service<CreepTriggerCommandSrv>(
+    "/api/external/set/creep_trigger_commands",
+    std::bind(&CreepGuidanceController::set_creep_trigger, this, _1, _2),
+    rmw_qos_profile_services_default, group_);
+
+  timer_ = rclcpp::create_timer(
+    this, get_clock(), 100ms, std::bind(&CreepGuidanceController::on_timer, this));
+}
+
+void CreepGuidanceController::on_timer()
+{
+  std::vector<CreepStatus> creep_statuses;
+  crosswalk_->insert_message(creep_statuses);
+  intersection_->insert_message(creep_statuses);
+  intersection_occlusion_->insert_message(creep_statuses);
+
+  align_creep_status_array(creep_statuses);
+
+  CreepStatusArray msg;
+  msg.stamp = now();
+  msg.statuses = creep_statuses;
+  creep_status_pub_->publish(msg);
+}
+
+void CreepGuidanceController::set_creep_trigger(
+  const CreepTriggerCommandSrv::Request::SharedPtr requests,
+  const CreepTriggerCommandSrv::Response::SharedPtr responses)
+{
+  for (tier4_creep_guidance_msgs::msg::CreepTriggerCommand & command : requests->commands) {
+    auto request = std::make_shared<CreepTriggerCommandSrv::Request>();
+    request->stamp = requests->stamp;
+    request->commands = {command};
+    switch (command.module.type) {
+      case Module::CROSSWALK: {
+        crosswalk_->call_service(request, responses);
+        break;
+      }
+      case Module::INTERSECTION: {
+        intersection_->call_service(request, responses);
+        break;
+      }
+      case Module::INTERSECTION_OCCLUSION: {
+        intersection_occlusion_->call_service(request, responses);
+        break;
+      }
+      case Module::NONE:
+      default: {
+        // Unknown module type, add a failure response
+        CreepTriggerResponse failure;
+        failure.id = command.id;
+        failure.module = command.module;
+        failure.success = false;
+        responses->responses.push_back(failure);
+        break;
+      }
+    }
+  }
+}
+
+}  // namespace external_api
+
+#include <rclcpp_components/register_node_macro.hpp>
+RCLCPP_COMPONENTS_REGISTER_NODE(external_api::CreepGuidanceController)

--- a/autoware_iv_external_api_adaptor/src/creep_guidance_controller.hpp
+++ b/autoware_iv_external_api_adaptor/src/creep_guidance_controller.hpp
@@ -1,0 +1,153 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CREEP_GUIDANCE_CONTROLLER_HPP_
+#define CREEP_GUIDANCE_CONTROLLER_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+#include <tier4_api_utils/tier4_api_utils.hpp>
+
+#include <tier4_creep_guidance_msgs/msg/command.hpp>
+#include <tier4_creep_guidance_msgs/msg/creep_status.hpp>
+#include <tier4_creep_guidance_msgs/msg/creep_status_array.hpp>
+#include <tier4_creep_guidance_msgs/msg/creep_trigger_command.hpp>
+#include <tier4_creep_guidance_msgs/msg/creep_trigger_response.hpp>
+#include <tier4_creep_guidance_msgs/msg/module.hpp>
+#include <tier4_creep_guidance_msgs/msg/state.hpp>
+#include <tier4_creep_guidance_msgs/srv/creep_trigger_command.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+using CreepTriggerCommandSrv = tier4_creep_guidance_msgs::srv::CreepTriggerCommand;
+using CreepStatusArray = tier4_creep_guidance_msgs::msg::CreepStatusArray;
+using CreepStatus = tier4_creep_guidance_msgs::msg::CreepStatus;
+using CreepTriggerCommand = tier4_creep_guidance_msgs::msg::CreepTriggerCommand;
+using CreepTriggerResponse = tier4_creep_guidance_msgs::msg::CreepTriggerResponse;
+using Module = tier4_creep_guidance_msgs::msg::Module;
+using Command = tier4_creep_guidance_msgs::msg::Command;
+using State = tier4_creep_guidance_msgs::msg::State;
+
+/**
+ * @brief Manages a single creep guidance module (crosswalk, intersection, or
+ * intersection_occlusion)
+ *
+ * This class handles communication with a specific creep guidance planning module,
+ * subscribing to its status and forwarding trigger commands to it.
+ */
+class CreepGuidanceModule
+{
+public:
+  std::vector<CreepStatus> module_statuses_;
+  rclcpp::Subscription<CreepStatusArray>::SharedPtr module_sub_;
+  rclcpp::CallbackGroup::SharedPtr client_callback_group_;
+  tier4_api_utils::Client<CreepTriggerCommandSrv>::SharedPtr cli_set_module_;
+  rclcpp::Logger logger_;
+
+  /**
+   * @brief Construct a new Creep Guidance Module object
+   * @param node Pointer to the parent ROS2 node
+   * @param name Name of the module (e.g., "crosswalk", "intersection", "intersection_occlusion")
+   */
+  CreepGuidanceModule(rclcpp::Node * node, const std::string & name);
+
+  /**
+   * @brief Callback function to receive and store creep status messages from the planning module
+   * @param message Received creep status array message
+   */
+  void module_callback(const CreepStatusArray::ConstSharedPtr message);
+
+  /**
+   * @brief Insert this module's statuses into the provided vector
+   * @param creep_statuses Vector to insert statuses into
+   */
+  void insert_message(std::vector<CreepStatus> & creep_statuses);
+
+  /**
+   * @brief Call the creep trigger command service for this module
+   * @param request Service request containing trigger commands
+   * @param responses Service response to accumulate results
+   */
+  void call_service(
+    CreepTriggerCommandSrv::Request::SharedPtr request,
+    const CreepTriggerCommandSrv::Response::SharedPtr & responses);
+};
+
+namespace external_api
+{
+/**
+ * @brief External API node for managing creep guidance across multiple modules
+ *
+ * This node acts as an external API interface for the creep guidance system.
+ * It manages three creep guidance modules (crosswalk, intersection, and intersection_occlusion),
+ * aggregates their statuses, and forwards trigger commands from external sources to the
+ * appropriate planning modules.
+ *
+ * Published Topics:
+ * - /api/external/get/creep_status (CreepStatusArray): Aggregated creep status from all modules
+ *
+ * Services:
+ * - /api/external/set/creep_trigger_commands (CreepTriggerCommand): Accepts trigger commands
+ *   and forwards them to the appropriate module
+ */
+class CreepGuidanceController : public rclcpp::Node
+{
+public:
+  /**
+   * @brief Construct a new Creep Guidance Controller object
+   * @param options ROS2 node options
+   */
+  explicit CreepGuidanceController(const rclcpp::NodeOptions & options);
+
+private:
+  std::unique_ptr<CreepGuidanceModule> crosswalk_;
+  std::unique_ptr<CreepGuidanceModule> intersection_;
+  std::unique_ptr<CreepGuidanceModule> intersection_occlusion_;
+
+  /* publishers */
+  rclcpp::Publisher<CreepStatusArray>::SharedPtr creep_status_pub_;
+
+  /* service from external */
+  rclcpp::CallbackGroup::SharedPtr group_;
+  tier4_api_utils::Service<CreepTriggerCommandSrv>::SharedPtr srv_set_creep_trigger_;
+
+  /* Timer */
+  rclcpp::TimerBase::SharedPtr timer_;
+
+  /**
+   * @brief Service callback to handle creep trigger commands from external API
+   *
+   * Routes each command to the appropriate module (crosswalk, intersection, or
+   * intersection_occlusion) based on the module type specified in the request.
+   *
+   * @param requests Service request containing trigger commands
+   * @param responses Service response containing results from each module
+   */
+  void set_creep_trigger(
+    const CreepTriggerCommandSrv::Request::SharedPtr requests,
+    const CreepTriggerCommandSrv::Response::SharedPtr responses);
+
+  /**
+   * @brief Timer callback to aggregate and publish creep status from all modules
+   *
+   * Called periodically (100ms) to collect status from all modules, sort them by
+   * start_distance, and publish the aggregated status to the external API.
+   */
+  void on_timer();
+};
+
+}  // namespace external_api
+
+#endif  // CREEP_GUIDANCE_CONTROLLER_HPP_


### PR DESCRIPTION
## Description

This pull request adds support for creep guidance functionality to the external API adaptor package. The main changes introduce a new `CreepGuidanceController` node, which aggregates status information from multiple creep guidance modules and forwards trigger commands to them. This enables external systems to interact with creep guidance features via standardized topics and services.