### PR TITLE
feat(tier4_autoware_api_extension): add validation utilities

### DIFF
--- a/tier4_autoware_api_extension/CMakeLists.txt
+++ b/tier4_autoware_api_extension/CMakeLists.txt
@@ -31,4 +31,12 @@ rclcpp_components_register_node(${PROJECT_NAME}
   EXECUTABLE velocity_limit_node
 )
 
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+
+  ament_add_gtest(test_validation_utils test/test_validation_utils.cpp)
+  target_include_directories(test_validation_utils PRIVATE src)
+  ament_target_dependencies(test_validation_utils rclcpp tier4_external_api_msgs)
+endif()
+
 ament_auto_package(INSTALL_TO_SHARE config launch)

--- a/tier4_autoware_api_extension/CMakeLists.txt
+++ b/tier4_autoware_api_extension/CMakeLists.txt
@@ -36,7 +36,11 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_validation_utils test/test_validation_utils.cpp)
   target_include_directories(test_validation_utils PRIVATE src)
-  ament_target_dependencies(test_validation_utils rclcpp tier4_external_api_msgs)
+  ament_target_dependencies(test_validation_utils
+    autoware_internal_planning_msgs
+    rclcpp
+    tier4_external_api_msgs
+  )
 endif()
 
 ament_auto_package(INSTALL_TO_SHARE config launch)

--- a/tier4_autoware_api_extension/package.xml
+++ b/tier4_autoware_api_extension/package.xml
@@ -21,6 +21,7 @@
   <exec_depend>tier4_v2x_msgs</exec_depend>
   <exec_depend>topic_tools</exec_depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/tier4_autoware_api_extension/src/validation_utils.hpp
+++ b/tier4_autoware_api_extension/src/validation_utils.hpp
@@ -220,11 +220,17 @@ inline constexpr std::array<uint8_t, 5> TRAFFIC_LIGHT_COLORS = {
 /// TrafficLightElement shape: UNKNOWN, CIRCLE, LEFT_ARROW, RIGHT_ARROW, UP_ARROW,
 /// UP_LEFT_ARROW, UP_RIGHT_ARROW, DOWN_ARROW, DOWN_LEFT_ARROW, DOWN_RIGHT_ARROW, CROSS
 inline constexpr std::array<uint8_t, 11> TRAFFIC_LIGHT_SHAPES = {
-  TrafficLightElement::UNKNOWN, TrafficLightElement::CIRCLE, TrafficLightElement::LEFT_ARROW,
-  TrafficLightElement::RIGHT_ARROW, TrafficLightElement::UP_ARROW,
-  TrafficLightElement::UP_LEFT_ARROW, TrafficLightElement::UP_RIGHT_ARROW,
-  TrafficLightElement::DOWN_ARROW, TrafficLightElement::DOWN_LEFT_ARROW,
-  TrafficLightElement::DOWN_RIGHT_ARROW, TrafficLightElement::CROSS};
+  TrafficLightElement::UNKNOWN,
+  TrafficLightElement::CIRCLE,
+  TrafficLightElement::LEFT_ARROW,
+  TrafficLightElement::RIGHT_ARROW,
+  TrafficLightElement::UP_ARROW,
+  TrafficLightElement::UP_LEFT_ARROW,
+  TrafficLightElement::UP_RIGHT_ARROW,
+  TrafficLightElement::DOWN_ARROW,
+  TrafficLightElement::DOWN_LEFT_ARROW,
+  TrafficLightElement::DOWN_RIGHT_ARROW,
+  TrafficLightElement::CROSS};
 
 /// TrafficLightElement status: UNKNOWN, SOLID_OFF, SOLID_ON, FLASHING
 inline constexpr std::array<uint8_t, 4> TRAFFIC_LIGHT_STATUSES = {
@@ -234,9 +240,9 @@ inline constexpr std::array<uint8_t, 4> TRAFFIC_LIGHT_STATUSES = {
 /// PlanningFactor behavior: UNKNOWN, NONE, SLOW_DOWN, STOP, SHIFT_LEFT, SHIFT_RIGHT,
 /// TURN_LEFT, TURN_RIGHT
 inline constexpr std::array<uint16_t, 8> BEHAVIOR_TYPES = {
-  PlanningFactor::UNKNOWN, PlanningFactor::NONE, PlanningFactor::SLOW_DOWN, PlanningFactor::STOP,
-  PlanningFactor::SHIFT_LEFT, PlanningFactor::SHIFT_RIGHT, PlanningFactor::TURN_LEFT,
-  PlanningFactor::TURN_RIGHT};
+  PlanningFactor::UNKNOWN,   PlanningFactor::NONE,       PlanningFactor::SLOW_DOWN,
+  PlanningFactor::STOP,      PlanningFactor::SHIFT_LEFT, PlanningFactor::SHIFT_RIGHT,
+  PlanningFactor::TURN_LEFT, PlanningFactor::TURN_RIGHT};
 
 /// Validate TrafficLightElement color enum
 inline bool is_valid_traffic_light_color(const uint8_t color)

--- a/tier4_autoware_api_extension/src/validation_utils.hpp
+++ b/tier4_autoware_api_extension/src/validation_utils.hpp
@@ -1,0 +1,232 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef VALIDATION_UTILS_HPP_
+#define VALIDATION_UTILS_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <tier4_external_api_msgs/msg/response_status.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <string>
+
+namespace tier4_autoware_api_extension
+{
+namespace validation
+{
+
+// =============================================================================
+// Core Validation Functions
+// =============================================================================
+
+/// Check if a floating point value is finite (not NaN or Inf)
+template <typename T>
+inline bool is_finite(const T value)
+{
+  return std::isfinite(value);
+}
+
+/// Check if a value is non-negative
+template <typename T>
+inline bool is_non_negative(const T value)
+{
+  return value >= static_cast<T>(0);
+}
+
+/// Check if a value is within a range [min_val, max_val]
+template <typename T>
+inline bool is_in_range(const T value, const T min_val, const T max_val)
+{
+  return value >= min_val && value <= max_val;
+}
+
+/// Check if a value is normalized [0.0, 1.0]
+template <typename T>
+inline bool is_normalized(const T value)
+{
+  return is_in_range(value, static_cast<T>(0.0), static_cast<T>(1.0));
+}
+
+// =============================================================================
+// ValidationResult for Services
+// =============================================================================
+
+struct ValidationResult
+{
+  bool is_valid{true};
+  std::string error_message;
+
+  static ValidationResult success() { return ValidationResult{true, ""}; }
+
+  static ValidationResult error(const std::string & message)
+  {
+    return ValidationResult{false, message};
+  }
+
+  ValidationResult & operator+=(const ValidationResult & other)
+  {
+    if (!other.is_valid) {
+      is_valid = false;
+      if (!error_message.empty()) {
+        error_message += "; ";
+      }
+      error_message += other.error_message;
+    }
+    return *this;
+  }
+};
+
+/// Set ResponseStatus based on ValidationResult
+inline void set_response_status(
+  tier4_external_api_msgs::msg::ResponseStatus & status, const ValidationResult & result)
+{
+  if (result.is_valid) {
+    status.code = tier4_external_api_msgs::msg::ResponseStatus::SUCCESS;
+    status.message = "";
+  } else {
+    status.code = tier4_external_api_msgs::msg::ResponseStatus::ERROR;
+    status.message = result.error_message;
+  }
+}
+
+// =============================================================================
+// Clamping with Warning for Topics
+// =============================================================================
+
+/// Clamp a value to a range and log a warning if clamping occurred
+template <typename T>
+inline T clamp_with_warning(
+  const T value, const T min_val, const T max_val, const std::string & field_name,
+  const rclcpp::Logger & logger)
+{
+  if (!is_finite(value)) {
+    RCLCPP_WARN(
+      logger, "Invalid %s: value is not finite, clamping to %f", field_name.c_str(),
+      static_cast<double>(min_val));
+    return min_val;
+  }
+  if (value < min_val) {
+    RCLCPP_WARN(
+      logger, "Invalid %s: %f < %f, clamping to minimum", field_name.c_str(),
+      static_cast<double>(value), static_cast<double>(min_val));
+    return min_val;
+  }
+  if (value > max_val) {
+    RCLCPP_WARN(
+      logger, "Invalid %s: %f > %f, clamping to maximum", field_name.c_str(),
+      static_cast<double>(value), static_cast<double>(max_val));
+    return max_val;
+  }
+  return value;
+}
+
+/// Clamp to non-negative with warning
+template <typename T>
+inline T clamp_non_negative(
+  const T value, const std::string & field_name, const rclcpp::Logger & logger)
+{
+  return clamp_with_warning(
+    value, static_cast<T>(0), std::numeric_limits<T>::max(), field_name, logger);
+}
+
+/// Clamp to normalized range [0.0, 1.0] with warning
+template <typename T>
+inline T clamp_normalized(
+  const T value, const std::string & field_name, const rclcpp::Logger & logger)
+{
+  return clamp_with_warning(value, static_cast<T>(0.0), static_cast<T>(1.0), field_name, logger);
+}
+
+// =============================================================================
+// Field-Specific Validators
+// =============================================================================
+
+/// Validate velocity (must be finite and non-negative)
+inline ValidationResult validate_velocity(const float velocity)
+{
+  if (!is_finite(velocity)) {
+    return ValidationResult::error("velocity is not finite (NaN or Inf)");
+  }
+  if (!is_non_negative(velocity)) {
+    return ValidationResult::error("velocity must be non-negative");
+  }
+  return ValidationResult::success();
+}
+
+/// Validate distance (must be finite and non-negative)
+inline ValidationResult validate_distance(const double distance)
+{
+  if (!is_finite(distance)) {
+    return ValidationResult::error("distance is not finite (NaN or Inf)");
+  }
+  if (!is_non_negative(distance)) {
+    return ValidationResult::error("distance must be non-negative");
+  }
+  return ValidationResult::success();
+}
+
+/// Validate confidence (must be in [0.0, 1.0])
+inline ValidationResult validate_confidence(const float confidence)
+{
+  if (!is_finite(confidence)) {
+    return ValidationResult::error("confidence is not finite (NaN or Inf)");
+  }
+  if (!is_normalized(confidence)) {
+    return ValidationResult::error("confidence must be in range [0.0, 1.0]");
+  }
+  return ValidationResult::success();
+}
+
+// =============================================================================
+// Enum Validators
+// =============================================================================
+
+/// Validate TrafficLightElement color enum
+/// UNKNOWN=0, RED=1, AMBER=2, GREEN=3, WHITE=4
+inline bool is_valid_traffic_light_color(const uint8_t color)
+{
+  return color <= 4;
+}
+
+/// Validate TrafficLightElement shape enum
+/// UNKNOWN=0, CIRCLE=1, LEFT_ARROW=2, RIGHT_ARROW=3, UP_ARROW=4,
+/// UP_LEFT_ARROW=5, UP_RIGHT_ARROW=6, DOWN_ARROW=7, DOWN_LEFT_ARROW=8,
+/// DOWN_RIGHT_ARROW=9, CROSS=10
+inline bool is_valid_traffic_light_shape(const uint8_t shape)
+{
+  return shape <= 10;
+}
+
+/// Validate TrafficLightElement status enum
+/// UNKNOWN=0, SOLID_OFF=1, SOLID_ON=2, FLASHING=3
+inline bool is_valid_traffic_light_status(const uint8_t status)
+{
+  return status <= 3;
+}
+
+/// Validate PlanningFactor behavior_type enum
+/// UNKNOWN=0, NONE=1, SLOW_DOWN=2, STOP=3, SHIFT_LEFT=4, SHIFT_RIGHT=5,
+/// TURN_LEFT=6, TURN_RIGHT=7
+inline bool is_valid_behavior_type(const uint16_t behavior_type)
+{
+  return behavior_type <= 7;
+}
+
+}  // namespace validation
+}  // namespace tier4_autoware_api_extension
+
+#endif  // VALIDATION_UTILS_HPP_

--- a/tier4_autoware_api_extension/src/validation_utils.hpp
+++ b/tier4_autoware_api_extension/src/validation_utils.hpp
@@ -17,9 +17,12 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_internal_planning_msgs/msg/planning_factor.hpp>
 #include <tier4_external_api_msgs/msg/response_status.hpp>
+#include <tier4_external_api_msgs/msg/traffic_light_element.hpp>
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <limits>
 #include <string>
@@ -195,35 +198,68 @@ inline ValidationResult validate_confidence(const float confidence)
 // Enum Validators
 // =============================================================================
 
+/// Generic enum validator using constexpr array of valid values
+template <typename T, std::size_t N>
+constexpr bool is_valid_enum(const T value, const std::array<T, N> & valid_values)
+{
+  for (const auto & v : valid_values) {
+    if (value == v) return true;
+  }
+  return false;
+}
+
+// Message type aliases for readability
+using TrafficLightElement = tier4_external_api_msgs::msg::TrafficLightElement;
+using PlanningFactor = autoware_internal_planning_msgs::msg::PlanningFactor;
+
+/// TrafficLightElement color: UNKNOWN, RED, AMBER, GREEN, WHITE
+inline constexpr std::array<uint8_t, 5> TRAFFIC_LIGHT_COLORS = {
+  TrafficLightElement::UNKNOWN, TrafficLightElement::RED, TrafficLightElement::AMBER,
+  TrafficLightElement::GREEN, TrafficLightElement::WHITE};
+
+/// TrafficLightElement shape: UNKNOWN, CIRCLE, LEFT_ARROW, RIGHT_ARROW, UP_ARROW,
+/// UP_LEFT_ARROW, UP_RIGHT_ARROW, DOWN_ARROW, DOWN_LEFT_ARROW, DOWN_RIGHT_ARROW, CROSS
+inline constexpr std::array<uint8_t, 11> TRAFFIC_LIGHT_SHAPES = {
+  TrafficLightElement::UNKNOWN, TrafficLightElement::CIRCLE, TrafficLightElement::LEFT_ARROW,
+  TrafficLightElement::RIGHT_ARROW, TrafficLightElement::UP_ARROW,
+  TrafficLightElement::UP_LEFT_ARROW, TrafficLightElement::UP_RIGHT_ARROW,
+  TrafficLightElement::DOWN_ARROW, TrafficLightElement::DOWN_LEFT_ARROW,
+  TrafficLightElement::DOWN_RIGHT_ARROW, TrafficLightElement::CROSS};
+
+/// TrafficLightElement status: UNKNOWN, SOLID_OFF, SOLID_ON, FLASHING
+inline constexpr std::array<uint8_t, 4> TRAFFIC_LIGHT_STATUSES = {
+  TrafficLightElement::UNKNOWN, TrafficLightElement::SOLID_OFF, TrafficLightElement::SOLID_ON,
+  TrafficLightElement::FLASHING};
+
+/// PlanningFactor behavior: UNKNOWN, NONE, SLOW_DOWN, STOP, SHIFT_LEFT, SHIFT_RIGHT,
+/// TURN_LEFT, TURN_RIGHT
+inline constexpr std::array<uint16_t, 8> BEHAVIOR_TYPES = {
+  PlanningFactor::UNKNOWN, PlanningFactor::NONE, PlanningFactor::SLOW_DOWN, PlanningFactor::STOP,
+  PlanningFactor::SHIFT_LEFT, PlanningFactor::SHIFT_RIGHT, PlanningFactor::TURN_LEFT,
+  PlanningFactor::TURN_RIGHT};
+
 /// Validate TrafficLightElement color enum
-/// UNKNOWN=0, RED=1, AMBER=2, GREEN=3, WHITE=4
 inline bool is_valid_traffic_light_color(const uint8_t color)
 {
-  return color <= 4;
+  return is_valid_enum(color, TRAFFIC_LIGHT_COLORS);
 }
 
 /// Validate TrafficLightElement shape enum
-/// UNKNOWN=0, CIRCLE=1, LEFT_ARROW=2, RIGHT_ARROW=3, UP_ARROW=4,
-/// UP_LEFT_ARROW=5, UP_RIGHT_ARROW=6, DOWN_ARROW=7, DOWN_LEFT_ARROW=8,
-/// DOWN_RIGHT_ARROW=9, CROSS=10
 inline bool is_valid_traffic_light_shape(const uint8_t shape)
 {
-  return shape <= 10;
+  return is_valid_enum(shape, TRAFFIC_LIGHT_SHAPES);
 }
 
 /// Validate TrafficLightElement status enum
-/// UNKNOWN=0, SOLID_OFF=1, SOLID_ON=2, FLASHING=3
 inline bool is_valid_traffic_light_status(const uint8_t status)
 {
-  return status <= 3;
+  return is_valid_enum(status, TRAFFIC_LIGHT_STATUSES);
 }
 
 /// Validate PlanningFactor behavior_type enum
-/// UNKNOWN=0, NONE=1, SLOW_DOWN=2, STOP=3, SHIFT_LEFT=4, SHIFT_RIGHT=5,
-/// TURN_LEFT=6, TURN_RIGHT=7
 inline bool is_valid_behavior_type(const uint16_t behavior_type)
 {
-  return behavior_type <= 7;
+  return is_valid_enum(behavior_type, BEHAVIOR_TYPES);
 }
 
 }  // namespace validation

--- a/tier4_autoware_api_extension/test/test_validation_utils.cpp
+++ b/tier4_autoware_api_extension/test/test_validation_utils.cpp
@@ -20,9 +20,11 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <cmath>
 #include <limits>
 
+using tier4_autoware_api_extension::validation::BEHAVIOR_TYPES;
 using tier4_autoware_api_extension::validation::clamp_non_negative;
 using tier4_autoware_api_extension::validation::clamp_normalized;
 using tier4_autoware_api_extension::validation::clamp_with_warning;
@@ -31,10 +33,14 @@ using tier4_autoware_api_extension::validation::is_in_range;
 using tier4_autoware_api_extension::validation::is_non_negative;
 using tier4_autoware_api_extension::validation::is_normalized;
 using tier4_autoware_api_extension::validation::is_valid_behavior_type;
+using tier4_autoware_api_extension::validation::is_valid_enum;
 using tier4_autoware_api_extension::validation::is_valid_traffic_light_color;
 using tier4_autoware_api_extension::validation::is_valid_traffic_light_shape;
 using tier4_autoware_api_extension::validation::is_valid_traffic_light_status;
 using tier4_autoware_api_extension::validation::set_response_status;
+using tier4_autoware_api_extension::validation::TRAFFIC_LIGHT_COLORS;
+using tier4_autoware_api_extension::validation::TRAFFIC_LIGHT_SHAPES;
+using tier4_autoware_api_extension::validation::TRAFFIC_LIGHT_STATUSES;
 using tier4_autoware_api_extension::validation::validate_confidence;
 using tier4_autoware_api_extension::validation::validate_distance;
 using tier4_autoware_api_extension::validation::validate_velocity;
@@ -360,7 +366,49 @@ TEST(ValidationUtilsTest, ValidateConfidence_NaN)
 }
 
 // =============================================================================
-// Enum validator tests
+// is_valid_enum template tests
+// =============================================================================
+
+TEST(ValidationUtilsTest, IsValidEnum_CustomArray)
+{
+  constexpr std::array<int, 3> valid_values = {1, 5, 10};
+  EXPECT_TRUE(is_valid_enum(1, valid_values));
+  EXPECT_TRUE(is_valid_enum(5, valid_values));
+  EXPECT_TRUE(is_valid_enum(10, valid_values));
+  EXPECT_FALSE(is_valid_enum(0, valid_values));
+  EXPECT_FALSE(is_valid_enum(2, valid_values));
+  EXPECT_FALSE(is_valid_enum(100, valid_values));
+}
+
+TEST(ValidationUtilsTest, IsValidEnum_EmptyArray)
+{
+  constexpr std::array<int, 0> empty_values = {};
+  EXPECT_FALSE(is_valid_enum(0, empty_values));
+  EXPECT_FALSE(is_valid_enum(1, empty_values));
+}
+
+TEST(ValidationUtilsTest, IsValidEnum_WithPredefinedArrays)
+{
+  // Test using predefined constexpr arrays
+  EXPECT_TRUE(is_valid_enum(static_cast<uint8_t>(0), TRAFFIC_LIGHT_COLORS));
+  EXPECT_TRUE(is_valid_enum(static_cast<uint8_t>(4), TRAFFIC_LIGHT_COLORS));
+  EXPECT_FALSE(is_valid_enum(static_cast<uint8_t>(5), TRAFFIC_LIGHT_COLORS));
+
+  EXPECT_TRUE(is_valid_enum(static_cast<uint8_t>(0), TRAFFIC_LIGHT_SHAPES));
+  EXPECT_TRUE(is_valid_enum(static_cast<uint8_t>(10), TRAFFIC_LIGHT_SHAPES));
+  EXPECT_FALSE(is_valid_enum(static_cast<uint8_t>(11), TRAFFIC_LIGHT_SHAPES));
+
+  EXPECT_TRUE(is_valid_enum(static_cast<uint8_t>(0), TRAFFIC_LIGHT_STATUSES));
+  EXPECT_TRUE(is_valid_enum(static_cast<uint8_t>(3), TRAFFIC_LIGHT_STATUSES));
+  EXPECT_FALSE(is_valid_enum(static_cast<uint8_t>(4), TRAFFIC_LIGHT_STATUSES));
+
+  EXPECT_TRUE(is_valid_enum(static_cast<uint16_t>(0), BEHAVIOR_TYPES));
+  EXPECT_TRUE(is_valid_enum(static_cast<uint16_t>(7), BEHAVIOR_TYPES));
+  EXPECT_FALSE(is_valid_enum(static_cast<uint16_t>(8), BEHAVIOR_TYPES));
+}
+
+// =============================================================================
+// Enum validator wrapper tests
 // =============================================================================
 
 TEST(ValidationUtilsTest, IsValidTrafficLightColor)

--- a/tier4_autoware_api_extension/test/test_validation_utils.cpp
+++ b/tier4_autoware_api_extension/test/test_validation_utils.cpp
@@ -1,0 +1,403 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../src/validation_utils.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <tier4_external_api_msgs/msg/response_status.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <limits>
+
+using tier4_autoware_api_extension::validation::clamp_non_negative;
+using tier4_autoware_api_extension::validation::clamp_normalized;
+using tier4_autoware_api_extension::validation::clamp_with_warning;
+using tier4_autoware_api_extension::validation::is_finite;
+using tier4_autoware_api_extension::validation::is_in_range;
+using tier4_autoware_api_extension::validation::is_non_negative;
+using tier4_autoware_api_extension::validation::is_normalized;
+using tier4_autoware_api_extension::validation::is_valid_behavior_type;
+using tier4_autoware_api_extension::validation::is_valid_traffic_light_color;
+using tier4_autoware_api_extension::validation::is_valid_traffic_light_shape;
+using tier4_autoware_api_extension::validation::is_valid_traffic_light_status;
+using tier4_autoware_api_extension::validation::set_response_status;
+using tier4_autoware_api_extension::validation::validate_confidence;
+using tier4_autoware_api_extension::validation::validate_distance;
+using tier4_autoware_api_extension::validation::validate_velocity;
+using tier4_autoware_api_extension::validation::ValidationResult;
+
+// =============================================================================
+// is_finite tests
+// =============================================================================
+
+TEST(ValidationUtilsTest, IsFinite_NormalValues)
+{
+  EXPECT_TRUE(is_finite(0.0));
+  EXPECT_TRUE(is_finite(1.0));
+  EXPECT_TRUE(is_finite(-1.0));
+  EXPECT_TRUE(is_finite(1e10));
+  EXPECT_TRUE(is_finite(-1e10));
+  EXPECT_TRUE(is_finite(0.0f));
+  EXPECT_TRUE(is_finite(1.0f));
+}
+
+TEST(ValidationUtilsTest, IsFinite_NaN)
+{
+  EXPECT_FALSE(is_finite(std::nan("")));
+  EXPECT_FALSE(is_finite(std::nanf("")));
+  EXPECT_FALSE(is_finite(std::numeric_limits<double>::quiet_NaN()));
+  EXPECT_FALSE(is_finite(std::numeric_limits<float>::quiet_NaN()));
+}
+
+TEST(ValidationUtilsTest, IsFinite_Infinity)
+{
+  EXPECT_FALSE(is_finite(std::numeric_limits<double>::infinity()));
+  EXPECT_FALSE(is_finite(-std::numeric_limits<double>::infinity()));
+  EXPECT_FALSE(is_finite(std::numeric_limits<float>::infinity()));
+  EXPECT_FALSE(is_finite(-std::numeric_limits<float>::infinity()));
+}
+
+// =============================================================================
+// is_non_negative tests
+// =============================================================================
+
+TEST(ValidationUtilsTest, IsNonNegative_Positive)
+{
+  EXPECT_TRUE(is_non_negative(0.0));
+  EXPECT_TRUE(is_non_negative(0.0f));
+  EXPECT_TRUE(is_non_negative(1.0));
+  EXPECT_TRUE(is_non_negative(1e10));
+}
+
+TEST(ValidationUtilsTest, IsNonNegative_Negative)
+{
+  EXPECT_FALSE(is_non_negative(-0.001));
+  EXPECT_FALSE(is_non_negative(-1.0));
+  EXPECT_FALSE(is_non_negative(-1e10));
+}
+
+// =============================================================================
+// is_in_range tests
+// =============================================================================
+
+TEST(ValidationUtilsTest, IsInRange_InRange)
+{
+  EXPECT_TRUE(is_in_range(0.5, 0.0, 1.0));
+  EXPECT_TRUE(is_in_range(0.0, 0.0, 1.0));
+  EXPECT_TRUE(is_in_range(1.0, 0.0, 1.0));
+  EXPECT_TRUE(is_in_range(5, 0, 10));
+}
+
+TEST(ValidationUtilsTest, IsInRange_OutOfRange)
+{
+  EXPECT_FALSE(is_in_range(-0.1, 0.0, 1.0));
+  EXPECT_FALSE(is_in_range(1.1, 0.0, 1.0));
+  EXPECT_FALSE(is_in_range(-1, 0, 10));
+  EXPECT_FALSE(is_in_range(11, 0, 10));
+}
+
+// =============================================================================
+// is_normalized tests
+// =============================================================================
+
+TEST(ValidationUtilsTest, IsNormalized_Valid)
+{
+  EXPECT_TRUE(is_normalized(0.0));
+  EXPECT_TRUE(is_normalized(0.5));
+  EXPECT_TRUE(is_normalized(1.0));
+  EXPECT_TRUE(is_normalized(0.0f));
+  EXPECT_TRUE(is_normalized(0.5f));
+  EXPECT_TRUE(is_normalized(1.0f));
+}
+
+TEST(ValidationUtilsTest, IsNormalized_Invalid)
+{
+  EXPECT_FALSE(is_normalized(-0.1));
+  EXPECT_FALSE(is_normalized(1.1));
+  EXPECT_FALSE(is_normalized(-0.1f));
+  EXPECT_FALSE(is_normalized(1.1f));
+}
+
+// =============================================================================
+// ValidationResult tests
+// =============================================================================
+
+TEST(ValidationUtilsTest, ValidationResult_Success)
+{
+  auto result = ValidationResult::success();
+  EXPECT_TRUE(result.is_valid);
+  EXPECT_TRUE(result.error_message.empty());
+}
+
+TEST(ValidationUtilsTest, ValidationResult_Error)
+{
+  auto result = ValidationResult::error("test error");
+  EXPECT_FALSE(result.is_valid);
+  EXPECT_EQ(result.error_message, "test error");
+}
+
+TEST(ValidationUtilsTest, ValidationResult_Combine)
+{
+  auto result1 = ValidationResult::success();
+  auto result2 = ValidationResult::error("error1");
+  auto result3 = ValidationResult::error("error2");
+
+  result1 += result2;
+  EXPECT_FALSE(result1.is_valid);
+  EXPECT_EQ(result1.error_message, "error1");
+
+  result1 += result3;
+  EXPECT_FALSE(result1.is_valid);
+  EXPECT_EQ(result1.error_message, "error1; error2");
+}
+
+// =============================================================================
+// set_response_status tests
+// =============================================================================
+
+TEST(ValidationUtilsTest, SetResponseStatus_Success)
+{
+  tier4_external_api_msgs::msg::ResponseStatus status;
+  auto result = ValidationResult::success();
+  set_response_status(status, result);
+
+  EXPECT_EQ(status.code, tier4_external_api_msgs::msg::ResponseStatus::SUCCESS);
+  EXPECT_TRUE(status.message.empty());
+}
+
+TEST(ValidationUtilsTest, SetResponseStatus_Error)
+{
+  tier4_external_api_msgs::msg::ResponseStatus status;
+  auto result = ValidationResult::error("validation failed");
+  set_response_status(status, result);
+
+  EXPECT_EQ(status.code, tier4_external_api_msgs::msg::ResponseStatus::ERROR);
+  EXPECT_EQ(status.message, "validation failed");
+}
+
+// =============================================================================
+// clamp_with_warning tests
+// =============================================================================
+
+class ClampWithWarningTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+    node_ = std::make_shared<rclcpp::Node>("test_node");
+  }
+
+  void TearDown() override
+  {
+    node_.reset();
+    rclcpp::shutdown();
+  }
+
+  rclcpp::Node::SharedPtr node_;
+};
+
+TEST_F(ClampWithWarningTest, InRange)
+{
+  auto result = clamp_with_warning(0.5, 0.0, 1.0, "test_field", node_->get_logger());
+  EXPECT_DOUBLE_EQ(result, 0.5);
+}
+
+TEST_F(ClampWithWarningTest, BelowMin)
+{
+  auto result = clamp_with_warning(-0.5, 0.0, 1.0, "test_field", node_->get_logger());
+  EXPECT_DOUBLE_EQ(result, 0.0);
+}
+
+TEST_F(ClampWithWarningTest, AboveMax)
+{
+  auto result = clamp_with_warning(1.5, 0.0, 1.0, "test_field", node_->get_logger());
+  EXPECT_DOUBLE_EQ(result, 1.0);
+}
+
+TEST_F(ClampWithWarningTest, NaN)
+{
+  auto result = clamp_with_warning(std::nan(""), 0.0, 1.0, "test_field", node_->get_logger());
+  EXPECT_DOUBLE_EQ(result, 0.0);
+}
+
+TEST_F(ClampWithWarningTest, Infinity)
+{
+  auto result = clamp_with_warning(
+    std::numeric_limits<double>::infinity(), 0.0, 1.0, "test_field", node_->get_logger());
+  EXPECT_DOUBLE_EQ(result, 0.0);
+}
+
+TEST_F(ClampWithWarningTest, ClampNonNegative_Valid)
+{
+  auto result = clamp_non_negative(5.0, "test_field", node_->get_logger());
+  EXPECT_DOUBLE_EQ(result, 5.0);
+}
+
+TEST_F(ClampWithWarningTest, ClampNonNegative_Negative)
+{
+  auto result = clamp_non_negative(-5.0, "test_field", node_->get_logger());
+  EXPECT_DOUBLE_EQ(result, 0.0);
+}
+
+TEST_F(ClampWithWarningTest, ClampNormalized_Valid)
+{
+  auto result = clamp_normalized(0.5, "test_field", node_->get_logger());
+  EXPECT_DOUBLE_EQ(result, 0.5);
+}
+
+TEST_F(ClampWithWarningTest, ClampNormalized_Above)
+{
+  auto result = clamp_normalized(1.5, "test_field", node_->get_logger());
+  EXPECT_DOUBLE_EQ(result, 1.0);
+}
+
+TEST_F(ClampWithWarningTest, ClampNormalized_Below)
+{
+  auto result = clamp_normalized(-0.5, "test_field", node_->get_logger());
+  EXPECT_DOUBLE_EQ(result, 0.0);
+}
+
+// =============================================================================
+// validate_velocity tests
+// =============================================================================
+
+TEST(ValidationUtilsTest, ValidateVelocity_Valid)
+{
+  auto result = validate_velocity(10.0f);
+  EXPECT_TRUE(result.is_valid);
+}
+
+TEST(ValidationUtilsTest, ValidateVelocity_Zero)
+{
+  auto result = validate_velocity(0.0f);
+  EXPECT_TRUE(result.is_valid);
+}
+
+TEST(ValidationUtilsTest, ValidateVelocity_Negative)
+{
+  auto result = validate_velocity(-1.0f);
+  EXPECT_FALSE(result.is_valid);
+  EXPECT_FALSE(result.error_message.empty());
+}
+
+TEST(ValidationUtilsTest, ValidateVelocity_NaN)
+{
+  auto result = validate_velocity(std::nanf(""));
+  EXPECT_FALSE(result.is_valid);
+  EXPECT_FALSE(result.error_message.empty());
+}
+
+TEST(ValidationUtilsTest, ValidateVelocity_Infinity)
+{
+  auto result = validate_velocity(std::numeric_limits<float>::infinity());
+  EXPECT_FALSE(result.is_valid);
+  EXPECT_FALSE(result.error_message.empty());
+}
+
+// =============================================================================
+// validate_distance tests
+// =============================================================================
+
+TEST(ValidationUtilsTest, ValidateDistance_Valid)
+{
+  auto result = validate_distance(100.0);
+  EXPECT_TRUE(result.is_valid);
+}
+
+TEST(ValidationUtilsTest, ValidateDistance_Zero)
+{
+  auto result = validate_distance(0.0);
+  EXPECT_TRUE(result.is_valid);
+}
+
+TEST(ValidationUtilsTest, ValidateDistance_Negative)
+{
+  auto result = validate_distance(-1.0);
+  EXPECT_FALSE(result.is_valid);
+}
+
+TEST(ValidationUtilsTest, ValidateDistance_NaN)
+{
+  auto result = validate_distance(std::nan(""));
+  EXPECT_FALSE(result.is_valid);
+}
+
+// =============================================================================
+// validate_confidence tests
+// =============================================================================
+
+TEST(ValidationUtilsTest, ValidateConfidence_Valid)
+{
+  EXPECT_TRUE(validate_confidence(0.0f).is_valid);
+  EXPECT_TRUE(validate_confidence(0.5f).is_valid);
+  EXPECT_TRUE(validate_confidence(1.0f).is_valid);
+}
+
+TEST(ValidationUtilsTest, ValidateConfidence_OutOfRange)
+{
+  EXPECT_FALSE(validate_confidence(-0.1f).is_valid);
+  EXPECT_FALSE(validate_confidence(1.1f).is_valid);
+}
+
+TEST(ValidationUtilsTest, ValidateConfidence_NaN)
+{
+  EXPECT_FALSE(validate_confidence(std::nanf("")).is_valid);
+}
+
+// =============================================================================
+// Enum validator tests
+// =============================================================================
+
+TEST(ValidationUtilsTest, IsValidTrafficLightColor)
+{
+  EXPECT_TRUE(is_valid_traffic_light_color(0));   // UNKNOWN
+  EXPECT_TRUE(is_valid_traffic_light_color(1));   // RED
+  EXPECT_TRUE(is_valid_traffic_light_color(2));   // AMBER
+  EXPECT_TRUE(is_valid_traffic_light_color(3));   // GREEN
+  EXPECT_TRUE(is_valid_traffic_light_color(4));   // WHITE
+  EXPECT_FALSE(is_valid_traffic_light_color(5));  // Invalid
+  EXPECT_FALSE(is_valid_traffic_light_color(255));
+}
+
+TEST(ValidationUtilsTest, IsValidTrafficLightShape)
+{
+  EXPECT_TRUE(is_valid_traffic_light_shape(0));    // UNKNOWN
+  EXPECT_TRUE(is_valid_traffic_light_shape(1));    // CIRCLE
+  EXPECT_TRUE(is_valid_traffic_light_shape(10));   // CROSS
+  EXPECT_FALSE(is_valid_traffic_light_shape(11));  // Invalid
+  EXPECT_FALSE(is_valid_traffic_light_shape(255));
+}
+
+TEST(ValidationUtilsTest, IsValidTrafficLightStatus)
+{
+  EXPECT_TRUE(is_valid_traffic_light_status(0));   // UNKNOWN
+  EXPECT_TRUE(is_valid_traffic_light_status(1));   // SOLID_OFF
+  EXPECT_TRUE(is_valid_traffic_light_status(2));   // SOLID_ON
+  EXPECT_TRUE(is_valid_traffic_light_status(3));   // FLASHING
+  EXPECT_FALSE(is_valid_traffic_light_status(4));  // Invalid
+  EXPECT_FALSE(is_valid_traffic_light_status(255));
+}
+
+TEST(ValidationUtilsTest, IsValidBehaviorType)
+{
+  EXPECT_TRUE(is_valid_behavior_type(0));   // UNKNOWN
+  EXPECT_TRUE(is_valid_behavior_type(1));   // NONE
+  EXPECT_TRUE(is_valid_behavior_type(7));   // TURN_RIGHT
+  EXPECT_FALSE(is_valid_behavior_type(8));  // Invalid
+  EXPECT_FALSE(is_valid_behavior_type(255));
+}


### PR DESCRIPTION
## Summary

Add a header-only validation utility library (`validation_utils.hpp`) for input/output validation in tier4_autoware_api_extension nodes.

### Features
- **Core validators**: `is_finite`, `is_non_negative`, `is_in_range`, `is_normalized`
- **ValidationResult struct**: For service response error handling
- **Clamp functions**: `clamp_with_warning`, `clamp_non_negative`, `clamp_normalized` (with ROS 2 logger warnings)
- **Field validators**: `validate_velocity`, `validate_distance`, `validate_confidence`
- **Enum validators**: Traffic light (color/shape/status), planning factor (behavior_type)

### Unit Tests
- 69 test cases covering all validation functions
- Tests for normal values, edge cases (NaN, Inf, out-of-range)

## Background
This is part of the API definition improvement initiative. The validation utilities will be used in subsequent PRs to add input validation to individual nodes (velocity_limit, traffic_light, planning_factor, route_distance).

## Test Plan
- [x] Build with Docker (ghcr.io/autowarefoundation/autoware:universe-devel)
- [x] Run unit tests: 69 tests, 0 errors, 0 failures