### PR TITLE
feat: add creep command service and client to RTC module

### DIFF
--- a/autoware_iv_external_api_adaptor/src/rtc_controller.cpp
+++ b/autoware_iv_external_api_adaptor/src/rtc_controller.cpp
@@ -36,6 +36,9 @@ RTCModule::RTCModule(rclcpp::Node * node, const std::string & name)
 
   cli_set_auto_mode_ = proxy.create_client<AutoMode>(
     enable_auto_mode_namespace_ + "/" + name, rmw_qos_profile_services_default);
+
+  cli_set_creep_ = proxy.create_client<CreepCommands>(
+    creep_commands_namespace_ + "/" + name, rmw_qos_profile_services_default);
 }
 
 void RTCModule::moduleCallback(const CooperateStatusArray::ConstSharedPtr message)
@@ -82,6 +85,17 @@ void RTCModule::callAutoModeService(
   response->success = resp->success;
 }
 
+void RTCModule::callCreepService(
+  CreepCommands::Request::SharedPtr request, const CreepCommands::Response::SharedPtr & responses)
+{
+  const auto [status, resp] = cli_set_creep_->call(request);
+  if (!tier4_api_utils::is_success(status)) {
+    return;
+  }
+  responses->responses.insert(
+    responses->responses.end(), resp->responses.begin(), resp->responses.end());
+}
+
 namespace external_api
 {
 RTCController::RTCController(const rclcpp::NodeOptions & options)
@@ -126,6 +140,9 @@ RTCController::RTCController(const rclcpp::NodeOptions & options)
     rmw_qos_profile_services_default, group_);
   srv_set_rtc_auto_mode_ = proxy.create_service<AutoModeWithModule>(
     "/api/external/set/rtc_auto_mode", std::bind(&RTCController::setRTCAutoMode, this, _1, _2),
+    rmw_qos_profile_services_default, group_);
+  srv_set_creep_ = proxy.create_service<CreepCommands>(
+    "/api/external/set/rtc_creep_commands", std::bind(&RTCController::setCreepRTC, this, _1, _2),
     rmw_qos_profile_services_default, group_);
 
   timer_ = rclcpp::create_timer(this, get_clock(), 100ms, std::bind(&RTCController::onTimer, this));
@@ -393,6 +410,95 @@ void RTCController::setRTCAutoMode(
       // virtual_traffic not found
   }
   response->success = auto_mode_response->success;
+}
+
+void RTCController::setCreepRTC(
+  const CreepCommands::Request::SharedPtr requests,
+  const CreepCommands::Response::SharedPtr responses)
+{
+  for (tier4_rtc_msgs::msg::CreepCommand & command : requests->commands) {
+    auto request = std::make_shared<CreepCommands::Request>();
+    request->stamp = requests->stamp;
+    request->commands = {command};
+    switch (command.module.type) {
+      case Module::LANE_CHANGE_LEFT: {
+        lane_change_left_->callCreepService(request, responses);
+        break;
+      }
+      case Module::LANE_CHANGE_RIGHT: {
+        lane_change_right_->callCreepService(request, responses);
+        break;
+      }
+      case Module::EXT_REQUEST_LANE_CHANGE_LEFT: {
+        ext_request_lane_change_left_->callCreepService(request, responses);
+        break;
+      }
+      case Module::EXT_REQUEST_LANE_CHANGE_RIGHT: {
+        ext_request_lane_change_right_->callCreepService(request, responses);
+        break;
+      }
+      case Module::AVOIDANCE_LEFT: {
+        avoidance_left_->callCreepService(request, responses);
+        break;
+      }
+      case Module::AVOIDANCE_RIGHT: {
+        avoidance_right_->callCreepService(request, responses);
+        break;
+      }
+      case Module::AVOIDANCE_BY_LC_LEFT: {
+        avoidance_by_lc_left_->callCreepService(request, responses);
+        break;
+      }
+      case Module::AVOIDANCE_BY_LC_RIGHT: {
+        avoidance_by_lc_right_->callCreepService(request, responses);
+        break;
+      }
+      case Module::GOAL_PLANNER: {
+        goal_planner_->callCreepService(request, responses);
+        break;
+      }
+      case Module::START_PLANNER: {
+        start_planner_->callCreepService(request, responses);
+        break;
+      }
+      case Module::TRAFFIC_LIGHT: {
+        traffic_light_->callCreepService(request, responses);
+        break;
+      }
+      case Module::INTERSECTION: {
+        intersection_->callCreepService(request, responses);
+        break;
+      }
+      case Module::INTERSECTION_OCCLUSION: {
+        intersection_occlusion_->callCreepService(request, responses);
+        break;
+      }
+      case Module::CROSSWALK: {
+        crosswalk_->callCreepService(request, responses);
+        break;
+      }
+      case Module::BLIND_SPOT: {
+        blind_spot_->callCreepService(request, responses);
+        break;
+      }
+      case Module::DETECTION_AREA: {
+        detection_area_->callCreepService(request, responses);
+        break;
+      }
+      case Module::NO_STOPPING_AREA: {
+        no_stopping_area_->callCreepService(request, responses);
+        break;
+      }
+      case Module::OCCLUSION_SPOT: {
+        occlusion_spot_->callCreepService(request, responses);
+        break;
+      }
+      case Module::SUPERVISED_PERCEPTION_FILTER: {
+        supervised_perception_filter_->callCreepService(request, responses);
+        break;
+      }
+    }
+  }
 }
 
 }  // namespace external_api

--- a/autoware_iv_external_api_adaptor/src/rtc_controller.cpp
+++ b/autoware_iv_external_api_adaptor/src/rtc_controller.cpp
@@ -170,7 +170,7 @@ void RTCController::insertionSortAndValidation(std::vector<CooperateStatus> & st
   }
 }
 
-void RTCController::checkInfDistance(CooperateStatus & status)  // Temporary fix for ROS2 humble
+void RTCController::checkInfDistance(CooperateStatus & status)  // Temporary fix for ROS 2 humble
 {
   if (!std::isfinite(status.start_distance)) {
     status.start_distance = -100000.0;

--- a/autoware_iv_external_api_adaptor/src/rtc_controller.hpp
+++ b/autoware_iv_external_api_adaptor/src/rtc_controller.hpp
@@ -23,10 +23,13 @@
 #include "tier4_rtc_msgs/msg/cooperate_command.hpp"
 #include "tier4_rtc_msgs/msg/cooperate_status.hpp"
 #include "tier4_rtc_msgs/msg/cooperate_status_array.hpp"
+#include "tier4_rtc_msgs/msg/creep_command.hpp"
+#include "tier4_rtc_msgs/msg/creep_response.hpp"
 #include "tier4_rtc_msgs/msg/module.hpp"
 #include "tier4_rtc_msgs/srv/auto_mode.hpp"
 #include "tier4_rtc_msgs/srv/auto_mode_with_module.hpp"
 #include "tier4_rtc_msgs/srv/cooperate_commands.hpp"
+#include "tier4_rtc_msgs/srv/creep_commands.hpp"
 
 #include <memory>
 #include <string>
@@ -35,10 +38,13 @@
 using CooperateCommands = tier4_rtc_msgs::srv::CooperateCommands;
 using AutoMode = tier4_rtc_msgs::srv::AutoMode;
 using AutoModeWithModule = tier4_rtc_msgs::srv::AutoModeWithModule;
+using CreepCommands = tier4_rtc_msgs::srv::CreepCommands;
 using AutoModeStatusArray = tier4_rtc_msgs::msg::AutoModeStatusArray;
 using AutoModeStatus = tier4_rtc_msgs::msg::AutoModeStatus;
 using CooperateStatusArray = tier4_rtc_msgs::msg::CooperateStatusArray;
 using CooperateStatus = tier4_rtc_msgs::msg::CooperateStatus;
+using CreepCommand = tier4_rtc_msgs::msg::CreepCommand;
+using CreepResponse = tier4_rtc_msgs::msg::CreepResponse;
 using Module = tier4_rtc_msgs::msg::Module;
 
 class RTCModule
@@ -48,12 +54,14 @@ public:
   std::string cooperate_commands_namespace_ = "/planning/cooperate_commands";
   std::string auto_mode_status_namespace_ = "/planning/auto_mode_status";
   std::string enable_auto_mode_namespace_ = "/planning/enable_auto_mode";
+  std::string creep_commands_namespace_ = "/planning/creep_commands";
   std::vector<CooperateStatus> module_statuses_;
   AutoModeStatus auto_mode_status_;
   rclcpp::Subscription<CooperateStatusArray>::SharedPtr module_sub_;
   rclcpp::Subscription<AutoModeStatus>::SharedPtr auto_mode_sub_;
   tier4_api_utils::Client<CooperateCommands>::SharedPtr cli_set_module_;
   tier4_api_utils::Client<AutoMode>::SharedPtr cli_set_auto_mode_;
+  tier4_api_utils::Client<CreepCommands>::SharedPtr cli_set_creep_;
 
   RTCModule(rclcpp::Node * node, const std::string & name);
   void moduleCallback(const CooperateStatusArray::ConstSharedPtr message);
@@ -65,6 +73,9 @@ public:
     const CooperateCommands::Response::SharedPtr & responses);
   void callAutoModeService(
     const AutoMode::Request::SharedPtr request, const AutoMode::Response::SharedPtr response);
+  void callCreepService(
+    CreepCommands::Request::SharedPtr request,
+    const CreepCommands::Response::SharedPtr & responses);
 };
 
 namespace external_api
@@ -103,6 +114,7 @@ private:
   rclcpp::CallbackGroup::SharedPtr group_;
   tier4_api_utils::Service<CooperateCommands>::SharedPtr srv_set_rtc_;
   tier4_api_utils::Service<AutoModeWithModule>::SharedPtr srv_set_rtc_auto_mode_;
+  tier4_api_utils::Service<CreepCommands>::SharedPtr srv_set_creep_;
 
   /* Timer */
   rclcpp::TimerBase::SharedPtr timer_;
@@ -117,6 +129,9 @@ private:
   void setRTCAutoMode(
     const AutoModeWithModule::Request::SharedPtr request,
     const AutoModeWithModule::Response::SharedPtr response);
+  void setCreepRTC(
+    const CreepCommands::Request::SharedPtr requests,
+    const CreepCommands::Response::SharedPtr responses);
 
   // ros callback
   void onTimer();


### PR DESCRIPTION
## Description

This PR updates the `RTCController` to support the new "Creep" feature. It acts as a bridge, exposing an external API endpoint that forwards creep commands from external systems to the relevant internal planning modules.

## Key Changes

**`RTCController`**:
* Added a new service server: `/api/external/set/rtc_creep_commands`.
* Implemented `setCreepRTC` to route incoming commands to the specific internal module instance (e.g., `intersection_`, `crosswalk_`) based on the module type ID.


**`RTCModule`**:
* Added a service client (`cli_set_creep_`) to communicate with the internal planning modules' `creep_commands` service.
* Added `callCreepService` to handle the request forwarding.