### PR TITLE
fix(autoware_iv_external_api_adaptor): add missing dependency to ament_index_cpp

### DIFF
--- a/autoware_iv_external_api_adaptor/package.xml
+++ b/autoware_iv_external_api_adaptor/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>ament_index_cpp</depend>
   <depend>autoware_adapi_specs</depend>
   <depend>autoware_component_interface_specs_universe</depend>
   <depend>autoware_component_interface_utils</depend>


### PR DESCRIPTION
## Description
autoware_iv_external uses ament_index_cpp, but the package does not have the dependency described in package.xml. This will fix the issue.

https://github.com/tier4/tier4_ad_api_adaptor/blob/6158491d2c100265938b6a2aaace42401ea7e726/autoware_iv_external_api_adaptor/src/metadata_packages.cpp#L17


## How the PR was tested
I have confirmed that the build passes both in ROS Humble and Jazzy