### PR TITLE
feat: add hazard status relay and refactor launch files

### DIFF
--- a/autoware_iv_internal_api_adaptor/launch/internal_api_relay.launch.xml
+++ b/autoware_iv_internal_api_adaptor/launch/internal_api_relay.launch.xml
@@ -1,20 +1,25 @@
 <launch>
   <group>
     <push-ros-namespace namespace="internal"/>
-    <node pkg="topic_tools" exec="relay" name="traffic_signals">
-      <param name="input_topic" value="/api/autoware/set/traffic_signals"/>
-      <param name="output_topic" value="/external/traffic_light_recognition/traffic_signals"/>
-      <param name="type" value="autoware_perception_msgs/msg/TrafficSignalArray"/>
-    </node>
-    <node pkg="topic_tools" exec="relay" name="intersection_states">
-      <param name="input_topic" value="/api/autoware/set/intersection_states"/>
-      <param name="output_topic" value="/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/input/external_intersection_states"/>
-      <param name="type" value="tier4_api_msgs/msg/IntersectionStatus"/>
-    </node>
-    <node pkg="topic_tools" exec="relay" name="crosswalk_states">
-      <param name="input_topic" value="/api/autoware/set/crosswalk_states"/>
-      <param name="output_topic" value="/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/input/external_crosswalk_states"/>
-      <param name="type" value="tier4_api_msgs/msg/CrosswalkStatus"/>
-    </node>
+    <node_container pkg="rclcpp_components" exec="component_container_mt" name="internal_api_relay_container" namespace=""/>
+
+    <include file="$(find-pkg-share autoware_iv_internal_api_adaptor)/launch/namespace.launch.py"/>
+    <load_composable_node target="$(var current_ros_namespace)/internal_api_relay_container">
+      <composable_node pkg="topic_tools" plugin="topic_tools::RelayNode" name="traffic_signals">
+        <param name="input_topic" value="/api/autoware/set/traffic_signals"/>
+        <param name="output_topic" value="/external/traffic_light_recognition/traffic_signals"/>
+        <param name="type" value="autoware_perception_msgs/msg/TrafficSignalArray"/>
+      </composable_node>
+      <composable_node pkg="topic_tools" plugin="topic_tools::RelayNode" name="intersection_states">
+        <param name="input_topic" value="/api/autoware/set/intersection_states"/>
+        <param name="output_topic" value="/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/input/external_intersection_states"/>
+        <param name="type" value="tier4_api_msgs/msg/IntersectionStatus"/>
+      </composable_node>
+      <composable_node pkg="topic_tools" plugin="topic_tools::RelayNode" name="crosswalk_states">
+        <param name="input_topic" value="/api/autoware/set/crosswalk_states"/>
+        <param name="output_topic" value="/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/input/external_crosswalk_states"/>
+        <param name="type" value="tier4_api_msgs/msg/CrosswalkStatus"/>
+      </composable_node>
+    </load_composable_node>
   </group>
 </launch>

--- a/autoware_iv_internal_api_adaptor/launch/namespace.launch.py
+++ b/autoware_iv_internal_api_adaptor/launch/namespace.launch.py
@@ -1,0 +1,26 @@
+# Copyright 2025 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchDescription
+from launch.actions import OpaqueFunction
+from launch.actions import SetLaunchConfiguration
+
+
+def current_ros_namespace(context):
+    namespace = context.launch_configurations.get("ros_namespace", "")
+    return [SetLaunchConfiguration("current_ros_namespace", namespace)]
+
+
+def generate_launch_description():
+    return LaunchDescription([OpaqueFunction(function=current_ros_namespace)])

--- a/tier4_autoware_api_extension/launch/namespace.launch.py
+++ b/tier4_autoware_api_extension/launch/namespace.launch.py
@@ -1,0 +1,26 @@
+# Copyright 2025 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchDescription
+from launch.actions import OpaqueFunction
+from launch.actions import SetLaunchConfiguration
+
+
+def current_ros_namespace(context):
+    namespace = context.launch_configurations.get("ros_namespace", "")
+    return [SetLaunchConfiguration("current_ros_namespace", namespace)]
+
+
+def generate_launch_description():
+    return LaunchDescription([OpaqueFunction(function=current_ros_namespace)])

--- a/tier4_autoware_api_extension/launch/tier4_autoware_api_extension.launch.xml
+++ b/tier4_autoware_api_extension/launch/tier4_autoware_api_extension.launch.xml
@@ -1,32 +1,61 @@
 <launch>
+  <arg name="api_mode" default="0" description="options: 0(All), 1(Without 2025/09 EOL API), 2(Without 2025/12 EOL API)"/>
+
+  <!-- Component Container -->
+  <group>
+    <push-ros-namespace namespace="tier4_api"/>
+    <node_container pkg="rclcpp_components" exec="component_container_mt" name="api_extension_container" namespace=""/>
+  </group>
+
   <!-- Nodes in this package. -->
   <group>
     <push-ros-namespace namespace="tier4_api"/>
-    <node pkg="tier4_autoware_api_extension" exec="route_distance_node"/>
-    <node pkg="tier4_autoware_api_extension" exec="traffic_light_node"/>
-    <node pkg="tier4_autoware_api_extension" exec="planning_factor_node">
-      <param from="$(find-pkg-share tier4_autoware_api_extension)/config/planning_factors.param.yaml"/>
-    </node>
+    <include file="$(find-pkg-share tier4_autoware_api_extension)/launch/namespace.launch.py"/>
+    <load_composable_node target="$(var current_ros_namespace)/api_extension_container">
+      <composable_node pkg="tier4_autoware_api_extension" plugin="tier4_autoware_api_extension::RouteDistance" name="route_distance"/>
+      <composable_node pkg="tier4_autoware_api_extension" plugin="tier4_autoware_api_extension::TrafficLight" name="traffic_light"/>
+      <composable_node pkg="tier4_autoware_api_extension" plugin="tier4_autoware_api_extension::PlanningFactor" name="planning_factor">
+        <param from="$(find-pkg-share tier4_autoware_api_extension)/config/planning_factors.param.yaml"/>
+      </composable_node>
+    </load_composable_node>
+  </group>
+
+  <!-- Nodes in this package. Switch for 2025/12 EOL API. -->
+  <group unless="$(eval &quot; $(var api_mode) &lt; 2 &quot;)">
+    <push-ros-namespace namespace="tier4_api"/>
+    <include file="$(find-pkg-share tier4_autoware_api_extension)/launch/namespace.launch.py"/>
+    <load_composable_node target="$(var current_ros_namespace)/api_extension_container">
+      <composable_node pkg="tier4_autoware_api_extension" plugin="tier4_autoware_api_extension::VelocityLimit" name="velocity_limit"/>
+    </load_composable_node>
   </group>
 
   <!-- Relay for tier4_v2x_msgs. -->
   <group>
     <push-ros-namespace namespace="tier4_api"/>
-    <node pkg="topic_tools" exec="relay" name="relay_virtual_traffic_light_status">
-      <param name="input_topic" value="/api/external/set/virtual_traffic_light/states"/>
-      <param name="output_topic" value="/awapi/tmp/virtual_traffic_light_states"/>
-      <param name="type" value="tier4_v2x_msgs/msg/VirtualTrafficLightStateArray"/>
-    </node>
-    <node pkg="topic_tools" exec="relay" name="relay_virtual_traffic_light_commands">
-      <param name="input_topic" value="/planning/scenario_planning/status/infrastructure_commands"/>
-      <param name="output_topic" value="/api/external/get/virtual_traffic_light/commands"/>
-      <param name="type" value="tier4_v2x_msgs/msg/InfrastructureCommandArray"/>
-    </node>
+    <include file="$(find-pkg-share tier4_autoware_api_extension)/launch/namespace.launch.py"/>
+    <load_composable_node target="$(var current_ros_namespace)/api_extension_container">
+      <composable_node pkg="topic_tools" plugin="topic_tools::RelayNode" name="relay_virtual_traffic_light_status">
+        <param name="input_topic" value="/api/external/set/virtual_traffic_light/states"/>
+        <param name="output_topic" value="/awapi/tmp/virtual_traffic_light_states"/>
+        <param name="type" value="tier4_v2x_msgs/msg/VirtualTrafficLightStateArray"/>
+      </composable_node>
+      <composable_node pkg="topic_tools" plugin="topic_tools::RelayNode" name="relay_virtual_traffic_light_commands">
+        <param name="input_topic" value="/planning/scenario_planning/status/infrastructure_commands"/>
+        <param name="output_topic" value="/api/external/get/virtual_traffic_light/commands"/>
+        <param name="type" value="tier4_v2x_msgs/msg/InfrastructureCommandArray"/>
+      </composable_node>
+    </load_composable_node>
   </group>
 
   <!-- For route distance. -->
   <group>
-    <push-ros-namespace namespace="tier4_api/utils"/>
-    <include file="$(find-pkg-share autoware_path_distance_calculator)/launch/path_distance_calculator.launch.xml"/>
+    <push-ros-namespace namespace="tier4_api"/>
+    <include file="$(find-pkg-share tier4_autoware_api_extension)/launch/namespace.launch.py"/>
+    <load_composable_node target="$(var current_ros_namespace)/api_extension_container">
+      <composable_node pkg="autoware_path_distance_calculator" plugin="autoware::path_distance_calculator::PathDistanceCalculator" name="path_distance_calculator" namespace="utils">
+        <remap from="~/input/path" to="/planning/scenario_planning/lane_driving/behavior_planning/path"/>
+        <remap from="~/output/distance" to="~/distance"/>
+      </composable_node>
+    </load_composable_node>
   </group>
 </launch>

--- a/tier4_deprecated_api_adapter/CMakeLists.txt
+++ b/tier4_deprecated_api_adapter/CMakeLists.txt
@@ -6,8 +6,13 @@ autoware_package()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/autoware_engage.cpp
+  src/hazard_status.cpp
   src/manual_control.cpp
   src/manual_status.cpp
+)
+
+rclcpp_components_register_nodes(${PROJECT_NAME}
+  "tier4_deprecated_api_adapter::HazardStatus"
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}

--- a/tier4_deprecated_api_adapter/launch/namespace.launch.py
+++ b/tier4_deprecated_api_adapter/launch/namespace.launch.py
@@ -1,0 +1,26 @@
+# Copyright 2025 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchDescription
+from launch.actions import OpaqueFunction
+from launch.actions import SetLaunchConfiguration
+
+
+def current_ros_namespace(context):
+    namespace = context.launch_configurations.get("ros_namespace", "")
+    return [SetLaunchConfiguration("current_ros_namespace", namespace)]
+
+
+def generate_launch_description():
+    return LaunchDescription([OpaqueFunction(function=current_ros_namespace)])

--- a/tier4_deprecated_api_adapter/launch/tier4_deprecated_api_adapter.launch.xml
+++ b/tier4_deprecated_api_adapter/launch/tier4_deprecated_api_adapter.launch.xml
@@ -19,5 +19,10 @@
         <param name="type" value="autoware_internal_debug_msgs/msg/Float64Stamped"/>
       </composable_node>
     </load_composable_node>
+
+    <!-- 2026/09 EOL API, launch regardless of the api_mode because it doesn't conflict with old implementation -->
+    <load_composable_node target="$(var current_ros_namespace)/deprecated_api_container">
+      <composable_node pkg="tier4_deprecated_api_adapter" plugin="tier4_deprecated_api_adapter::HazardStatus" name="hazard_status"/>
+    </load_composable_node>
   </group>
 </launch>

--- a/tier4_deprecated_api_adapter/launch/tier4_deprecated_api_adapter.launch.xml
+++ b/tier4_deprecated_api_adapter/launch/tier4_deprecated_api_adapter.launch.xml
@@ -1,17 +1,23 @@
 <launch>
   <group>
     <push-ros-namespace namespace="tier4_api"/>
-    <node pkg="tier4_deprecated_api_adapter" exec="autoware_engage_node" name="engage"/>
+    <node_container pkg="rclcpp_components" exec="component_container_mt" name="deprecated_api_container" namespace=""/>
 
-    <group>
-      <push-ros-namespace namespace="manual"/>
-      <node pkg="tier4_deprecated_api_adapter" exec="manual_status_node" name="status"/>
-      <node pkg="tier4_deprecated_api_adapter" exec="manual_control_node" name="local">
+    <include file="$(find-pkg-share tier4_deprecated_api_adapter)/launch/namespace.launch.py"/>
+    <load_composable_node target="$(var current_ros_namespace)/deprecated_api_container">
+      <composable_node pkg="tier4_deprecated_api_adapter" plugin="tier4_deprecated_api_adapter::AutowareEngage" name="engage"/>
+      <composable_node pkg="tier4_deprecated_api_adapter" plugin="tier4_deprecated_api_adapter::ManualStatus" name="status" namespace="manual"/>
+      <composable_node pkg="tier4_deprecated_api_adapter" plugin="tier4_deprecated_api_adapter::ManualControl" name="local" namespace="manual">
         <param name="mode" value="local"/>
-      </node>
-      <node pkg="tier4_deprecated_api_adapter" exec="manual_control_node" name="remote">
+      </composable_node>
+      <composable_node pkg="tier4_deprecated_api_adapter" plugin="tier4_deprecated_api_adapter::ManualControl" name="remote" namespace="manual">
         <param name="mode" value="remote"/>
-      </node>
-    </group>
+      </composable_node>
+      <composable_node pkg="topic_tools" plugin="topic_tools::RelayNode" name="relay_route_distance">
+        <param name="input_topic" value="/tier4_api/utils/path_distance_calculator/distance"/>
+        <param name="output_topic" value="/autoware_api/utils/path_distance_calculator/distance"/>
+        <param name="type" value="autoware_internal_debug_msgs/msg/Float64Stamped"/>
+      </composable_node>
+    </load_composable_node>
   </group>
 </launch>

--- a/tier4_deprecated_api_adapter/package.xml
+++ b/tier4_deprecated_api_adapter/package.xml
@@ -12,6 +12,7 @@
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_control_msgs</depend>
+  <depend>autoware_system_msgs</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/tier4_deprecated_api_adapter/src/hazard_status.cpp
+++ b/tier4_deprecated_api_adapter/src/hazard_status.cpp
@@ -1,0 +1,45 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "hazard_status.hpp"
+
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace tier4_deprecated_api_adapter
+{
+
+HazardStatus::HazardStatus(const rclcpp::NodeOptions & options) : Node("hazard_status", options)
+{
+  const auto on_message = [this](const InternalMessage & internal) {
+    ExternalMessage external;
+    external.stamp = internal.stamp;
+    external.status.level = internal.status.level;
+    external.status.emergency = internal.status.emergency;
+    external.status.emergency_holding = internal.status.emergency_holding;
+    external.status.diag_no_fault = internal.status.diag_no_fault;
+    external.status.diag_safe_fault = internal.status.diag_safe_fault;
+    external.status.diag_latent_fault = internal.status.diag_latent_fault;
+    external.status.diag_single_point_fault = internal.status.diag_single_point_fault;
+    pub_->publish(external);
+  };
+  pub_ = create_publisher<ExternalMessage>("/api/external/get/hazard_status", 1);
+  sub_ = create_subscription<InternalMessage>("/system/emergency/hazard_status", 1, on_message);
+}
+
+}  // namespace tier4_deprecated_api_adapter
+
+#include <rclcpp_components/register_node_macro.hpp>
+RCLCPP_COMPONENTS_REGISTER_NODE(tier4_deprecated_api_adapter::HazardStatus)

--- a/tier4_deprecated_api_adapter/src/hazard_status.hpp
+++ b/tier4_deprecated_api_adapter/src/hazard_status.hpp
@@ -1,0 +1,40 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef HAZARD_STATUS_HPP_
+#define HAZARD_STATUS_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_system_msgs/msg/hazard_status_stamped.hpp>
+#include <tier4_external_api_msgs/msg/hazard_status_stamped.hpp>
+
+namespace tier4_deprecated_api_adapter
+{
+
+class HazardStatus : public rclcpp::Node
+{
+public:
+  explicit HazardStatus(const rclcpp::NodeOptions & options);
+
+private:
+  using ExternalMessage = tier4_external_api_msgs::msg::HazardStatusStamped;
+  using InternalMessage = autoware_system_msgs::msg::HazardStatusStamped;
+  rclcpp::Publisher<ExternalMessage>::SharedPtr pub_;
+  rclcpp::Subscription<InternalMessage>::SharedPtr sub_;
+};
+
+}  // namespace tier4_deprecated_api_adapter
+
+#endif  // HAZARD_STATUS_HPP_


### PR DESCRIPTION
## Description
Extends support for hazard status for TIER IV database compatibility.

## Related links
[TIER IV internal link](https://star4.slack.com/archives/C017VB9UG1L/p1764755261143539?thread_ts=1729675438.504999&cid=C017VB9UG1L)

https://github.com/tier4/autoware_universe/pull/2640
https://github.com/tier4/tier4_autoware_msgs/pull/209

[Source PR 1](https://github.com/tier4/tier4_ad_api_adaptor/pull/193)
[Source PR 2](https://github.com/tier4/tier4_ad_api_adaptor/pull/187)

## How was this PR tested?
Please refer to [PR#2640](https://github.com/tier4/autoware_universe/pull/2640)

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.

