### PR TITLE
fix(awapi_awiv_adapter_node): fix vehicle cmd qos volatile

### DIFF
--- a/awapi_awiv_adapter/src/awapi_awiv_adapter_core.cpp
+++ b/awapi_awiv_adapter/src/awapi_awiv_adapter_core.cpp
@@ -69,7 +69,7 @@ AutowareIvAdapter::AutowareIvAdapter()
   sub_steer_ = this->create_subscription<autoware_vehicle_msgs::msg::SteeringReport>(
     "input/steer", 1, std::bind(&AutowareIvAdapter::callbackSteer, this, _1));
   sub_vehicle_cmd_ = this->create_subscription<autoware_control_msgs::msg::Control>(
-    "input/vehicle_cmd", durable_qos, std::bind(&AutowareIvAdapter::callbackVehicleCmd, this, _1));
+    "input/vehicle_cmd", 1, std::bind(&AutowareIvAdapter::callbackVehicleCmd, this, _1));
   sub_turn_indicators_ =
     this->create_subscription<autoware_vehicle_msgs::msg::TurnIndicatorsReport>(
       "input/turn_indicators", 1, std::bind(&AutowareIvAdapter::callbackTurnIndicators, this, _1));


### PR DESCRIPTION
## Description

The subscriber QoS for `/control/command/control_cmd` of `awapi_awiv_adapter_node` was set to `transient_local`.
However, some control command publishers like `control_command_gate` publish the `control_cmd` topic with `volatile` QoS.
https://github.com/autowarefoundation/autoware_universe/blob/0e68ac7c13f8e7b8299e5c10511662acf23f65f4/control/autoware_control_command_gate/src/command/publisher.cpp#L24-L27

This meant that `awapi_awiv_adapter_node` did not receive these topics. Therefore, this PR fixes this issue.

## Related links

- [TIER IV internal](https://star4.slack.com/archives/C05BEU7GFA9/p1770109689174199)

## How was this PR tested?

I ran the planning simulator as follows:
```
autoware@npc2407515:/workspaces/autoware$ ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit launch_deprecated_api:=true api_mode:=1
```

And checked the subscriber settings with `ros2 topic info -v /control/command/control_cmd`.

After Change
```
Node name: awapi_awiv_adapter_node
Node namespace: /awapi
Topic type: autoware_control_msgs/msg/Control
Endpoint type: SUBSCRIPTION
GID: 01.10.23.d9.49.ea.5e.0f.fe.e5.6b.28.00.00.37.04.00.00.00.00.00.00.00.00
QoS profile:
  Reliability: RELIABLE
  History (Depth): KEEP_LAST (1)
  Durability: VOLATILE
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite
```


## Notes for reviewers

Please note volatile subscriber can receive topic from transient local publisher.