### PR TITLE
fix: avoid route_state error on FMS

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
       - id: yamllint
 
   - repo: https://github.com/tier4/pre-commit-hooks-ros
-    rev: v0.8.0
+    rev: v0.10.2
     hooks:
       - id: flake8-ros
       - id: prettier-xacro

--- a/awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp
+++ b/awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp
@@ -166,10 +166,21 @@ void AutowareIvAutowareStatePublisher::getHazardStatusInfo(
 
     auto spf =
       diagnostics_filter::extractLeafDiagnostics(status->hazard_status.status.diagnostics_spf);
-    if (
-      // it's not changed status->arrived_goal if set force goal.
-      status->autoware_state == AutowareState::WAITING_FOR_ROUTE) {
-      const auto should_downgrade_error_to_ok = [](const DiagnosticStatus & d) -> bool {
+
+    const bool wfr = (status->autoware_state == AutowareState::WAITING_FOR_ROUTE);
+    const bool pln = (status->autoware_state == AutowareState::PLANNING);
+    // it's not changed status->arrived_goal if set force goal.
+    if (wfr || pln) {
+      const auto should_downgrade = [wfr, pln](const DiagnosticStatus & d) -> bool {
+        const bool routing_unset =
+          d.name == "/adapi/node/routing: state" && d.values.empty() &&
+          d.message == "2" && d.hardware_id == "none";  // tier4_planning_msgs/RouteState UNSET
+        if (pln) {
+          return routing_unset ||
+                 (d.level == DiagnosticStatus::ERROR && d.values.empty() && d.message.empty() &&
+                  d.hardware_id.empty() &&
+                  d.name == "/planning/000-component_status/route_state");
+        }
         if (
           d.level == DiagnosticStatus::STALE && d.values.empty() && d.message.empty() &&
           d.hardware_id.empty() && d.name == "vehicle_cmd_gate: emergency_stop_operation") {
@@ -185,20 +196,15 @@ void AutowareIvAutowareStatePublisher::getHazardStatusInfo(
                  d.name == "/system/002-emergency_stop_operation/vehicle_cmd_gate" ||
                  d.name == "/planning/000-component_status/route_state";
         }
-        if (
-          d.name == "/adapi/node/routing: state" && d.values.empty() && d.message == "2" &&
-          d.hardware_id == "none") {
-          return true;
-        }
-
-        return false;
+        return routing_unset;
       };
       for (auto & d : spf) {
-        if (should_downgrade_error_to_ok(d)) {
+        if (should_downgrade(d)) {
           d.level = DiagnosticStatus::OK;
         }
       }
     }
+
     status->hazard_status.status.diagnostics_spf = std::move(spf);
   }
   status->hazard_status.status.diagnostics_lf =

--- a/awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp
+++ b/awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp
@@ -183,6 +183,7 @@ void AutowareIvAutowareStatePublisher::getHazardStatusInfo(
         return d.name == "/autoware/modes/autonomous" ||
                d.name == "/planning/autonomous_available" ||
                d.name == "/planning/in_lane_moderate_stop" ||
+               d.name == "/planning/emergency_stop" ||
                d.name == "/planning/000-component_status/route_state";
       };
       for (auto & d : spf) {

--- a/awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp
+++ b/awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp
@@ -17,6 +17,9 @@
 #include "awapi_awiv_adapter/diagnostics_filter.hpp"
 #include "tier4_auto_msgs_converter/tier4_auto_msgs_converter.hpp"
 
+#include <diagnostic_msgs/msg/diagnostic_status.hpp>
+
+#include <algorithm>
 #include <regex>
 #include <string>
 #include <vector>
@@ -158,8 +161,38 @@ void AutowareIvAutowareStatePublisher::getHazardStatusInfo(
   status->hazard_status = convert(*aw_info.hazard_status_ptr);
 
   // filter leaf diagnostics
-  status->hazard_status.status.diagnostics_spf =
-    diagnostics_filter::extractLeafDiagnostics(status->hazard_status.status.diagnostics_spf);
+  {
+    using diagnostic_msgs::msg::DiagnosticStatus;
+    using tier4_system_msgs::msg::AutowareState;
+
+    auto spf =
+      diagnostics_filter::extractLeafDiagnostics(status->hazard_status.status.diagnostics_spf);
+    if (
+      status->autoware_state == AutowareState::WAITING_FOR_ROUTE && status->arrived_goal) {
+      spf.erase(
+        std::remove_if(
+          spf.begin(), spf.end(),
+          [](const DiagnosticStatus & d) {
+            if (d.level != DiagnosticStatus::ERROR || !d.values.empty()) {
+              return false;
+            }
+            if (
+              d.name == "/adapi/node/routing: state" && d.message == "2" &&
+              (d.hardware_id.empty() || d.hardware_id == "none")) {
+              return true;
+            }
+            if (!d.message.empty() || !d.hardware_id.empty()) {
+              return false;
+            }
+            return d.name == "/autoware/modes/autonomous" ||
+                   d.name == "/planning/autonomous_available" ||
+                   d.name == "/planning/in_lane_moderate_stop" ||
+                   d.name == "/planning/000-component_status/route_state";
+          }),
+        spf.end());
+    }
+    status->hazard_status.status.diagnostics_spf = std::move(spf);
+  }
   status->hazard_status.status.diagnostics_lf =
     diagnostics_filter::extractLeafDiagnostics(status->hazard_status.status.diagnostics_lf);
   status->hazard_status.status.diagnostics_sf =

--- a/awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp
+++ b/awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp
@@ -167,16 +167,15 @@ void AutowareIvAutowareStatePublisher::getHazardStatusInfo(
     auto spf =
       diagnostics_filter::extractLeafDiagnostics(status->hazard_status.status.diagnostics_spf);
 
-    const bool waiting_for_route =
-      (status->autoware_state == AutowareState::WAITING_FOR_ROUTE);
+    const bool waiting_for_route = (status->autoware_state == AutowareState::WAITING_FOR_ROUTE);
     const bool planning = (status->autoware_state == AutowareState::PLANNING);
     // it's not changed status->arrived_goal if set force goal.
     if (waiting_for_route || planning) {
-      const auto should_downgrade = [waiting_for_route, planning](
-                                      const DiagnosticStatus & d) -> bool {
+      const auto should_downgrade = [waiting_for_route,
+                                     planning](const DiagnosticStatus & d) -> bool {
         const bool routing_unset =
-          d.name == "/adapi/node/routing: state" && d.values.empty() &&
-          d.message == "2" && d.hardware_id == "none";  // autoware_planning_msgs/RouteState::UNSET
+          d.name == "/adapi/node/routing: state" && d.values.empty() && d.message == "2" &&
+          d.hardware_id == "none";  // autoware_planning_msgs/RouteState::UNSET
 
         if (planning) {
           const bool empty_error = d.level == DiagnosticStatus::ERROR && d.values.empty() &&

--- a/awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp
+++ b/awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp
@@ -19,7 +19,6 @@
 
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 
-#include <algorithm>
 #include <regex>
 #include <string>
 #include <vector>
@@ -169,27 +168,28 @@ void AutowareIvAutowareStatePublisher::getHazardStatusInfo(
       diagnostics_filter::extractLeafDiagnostics(status->hazard_status.status.diagnostics_spf);
     if (
       status->autoware_state == AutowareState::WAITING_FOR_ROUTE && status->arrived_goal) {
-      spf.erase(
-        std::remove_if(
-          spf.begin(), spf.end(),
-          [](const DiagnosticStatus & d) {
-            if (d.level != DiagnosticStatus::ERROR || !d.values.empty()) {
-              return false;
-            }
-            if (
-              d.name == "/adapi/node/routing: state" && d.message == "2" &&
-              (d.hardware_id.empty() || d.hardware_id == "none")) {
-              return true;
-            }
-            if (!d.message.empty() || !d.hardware_id.empty()) {
-              return false;
-            }
-            return d.name == "/autoware/modes/autonomous" ||
-                   d.name == "/planning/autonomous_available" ||
-                   d.name == "/planning/in_lane_moderate_stop" ||
-                   d.name == "/planning/000-component_status/route_state";
-          }),
-        spf.end());
+      const auto should_downgrade_error_to_ok = [](const DiagnosticStatus & d) -> bool {
+        if (d.level != DiagnosticStatus::ERROR || !d.values.empty()) {
+          return false;
+        }
+        if (
+          d.name == "/adapi/node/routing: state" && d.message == "2" &&
+          (d.hardware_id.empty() || d.hardware_id == "none")) {
+          return true;
+        }
+        if (!d.message.empty() || !d.hardware_id.empty()) {
+          return false;
+        }
+        return d.name == "/autoware/modes/autonomous" ||
+               d.name == "/planning/autonomous_available" ||
+               d.name == "/planning/in_lane_moderate_stop" ||
+               d.name == "/planning/000-component_status/route_state";
+      };
+      for (auto & d : spf) {
+        if (should_downgrade_error_to_ok(d)) {
+          d.level = DiagnosticStatus::OK;
+        }
+      }
     }
     status->hazard_status.status.diagnostics_spf = std::move(spf);
   }

--- a/awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp
+++ b/awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp
@@ -185,6 +185,8 @@ void AutowareIvAutowareStatePublisher::getHazardStatusInfo(
                d.name == "/planning/autonomous_available" ||
                d.name == "/planning/in_lane_moderate_stop" ||
                d.name == "/planning/emergency_stop" ||
+               d.name == "/system/002-emergency_stop_operation/vehicle_cmd_gate" ||
+               d.name == "vehicle_cmd_gate: emergency_stop_operation" ||
                d.name == "/planning/000-component_status/route_state";
       };
       for (auto & d : spf) {

--- a/awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp
+++ b/awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp
@@ -169,7 +169,7 @@ void AutowareIvAutowareStatePublisher::getHazardStatusInfo(
 
     const bool waiting_for_route = (status->autoware_state == AutowareState::WAITING_FOR_ROUTE);
     const bool planning = (status->autoware_state == AutowareState::PLANNING);
-    // it's not changed status->arrived_goal if set force goal.
+    // status->arrived_goal is not updated when a forced-goal condition is used.
     if (waiting_for_route || planning) {
       const auto should_downgrade = [waiting_for_route,
                                      planning](const DiagnosticStatus & d) -> bool {

--- a/awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp
+++ b/awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp
@@ -167,7 +167,8 @@ void AutowareIvAutowareStatePublisher::getHazardStatusInfo(
     auto spf =
       diagnostics_filter::extractLeafDiagnostics(status->hazard_status.status.diagnostics_spf);
     if (
-      status->autoware_state == AutowareState::WAITING_FOR_ROUTE && status->arrived_goal) {
+      // it's not changed status->arrived_goal if set force goal.
+      status->autoware_state == AutowareState::WAITING_FOR_ROUTE ) {
       const auto should_downgrade_error_to_ok = [](const DiagnosticStatus & d) -> bool {
         if (d.level != DiagnosticStatus::ERROR || !d.values.empty()) {
           return false;

--- a/awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp
+++ b/awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp
@@ -170,24 +170,35 @@ void AutowareIvAutowareStatePublisher::getHazardStatusInfo(
       // it's not changed status->arrived_goal if set force goal.
       status->autoware_state == AutowareState::WAITING_FOR_ROUTE ) {
       const auto should_downgrade_error_to_ok = [](const DiagnosticStatus & d) -> bool {
-        if (d.level != DiagnosticStatus::ERROR || !d.values.empty()) {
-          return false;
-        }
         if (
-          d.name == "/adapi/node/routing: state" && d.message == "2" &&
-          (d.hardware_id.empty() || d.hardware_id == "none")) {
+          d.level == DiagnosticStatus::STALE && 
+          d.values.empty() && 
+          d.message.empty() &&
+          d.hardware_id.empty() &&
+          d.name == "vehicle_cmd_gate: emergency_stop_operation") {
           return true;
         }
-        if (!d.message.empty() || !d.hardware_id.empty()) {
-          return false;
+        if (
+          d.level == DiagnosticStatus::ERROR && 
+          d.values.empty() &&
+          d.message.empty() &&
+          d.hardware_id.empty()) {
+          return  d.name == "/autoware/modes/autonomous" ||
+                  d.name == "/planning/autonomous_available" ||
+                  d.name == "/planning/in_lane_moderate_stop" ||
+                  d.name == "/planning/emergency_stop" ||
+                  d.name == "/system/002-emergency_stop_operation/vehicle_cmd_gate" ||
+                  d.name == "/planning/000-component_status/route_state";
         }
-        return d.name == "/autoware/modes/autonomous" ||
-               d.name == "/planning/autonomous_available" ||
-               d.name == "/planning/in_lane_moderate_stop" ||
-               d.name == "/planning/emergency_stop" ||
-               d.name == "/system/002-emergency_stop_operation/vehicle_cmd_gate" ||
-               d.name == "vehicle_cmd_gate: emergency_stop_operation" ||
-               d.name == "/planning/000-component_status/route_state";
+        if (
+          d.name == "/adapi/node/routing: state" && 
+          d.values.empty() &&
+          d.message == "2" &&
+          d.hardware_id == "none") {
+          return true;
+        }
+        
+        return false;
       };
       for (auto & d : spf) {
         if (should_downgrade_error_to_ok(d)) {

--- a/awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp
+++ b/awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp
@@ -168,36 +168,29 @@ void AutowareIvAutowareStatePublisher::getHazardStatusInfo(
       diagnostics_filter::extractLeafDiagnostics(status->hazard_status.status.diagnostics_spf);
     if (
       // it's not changed status->arrived_goal if set force goal.
-      status->autoware_state == AutowareState::WAITING_FOR_ROUTE ) {
+      status->autoware_state == AutowareState::WAITING_FOR_ROUTE) {
       const auto should_downgrade_error_to_ok = [](const DiagnosticStatus & d) -> bool {
         if (
-          d.level == DiagnosticStatus::STALE && 
-          d.values.empty() && 
-          d.message.empty() &&
-          d.hardware_id.empty() &&
-          d.name == "vehicle_cmd_gate: emergency_stop_operation") {
+          d.level == DiagnosticStatus::STALE && d.values.empty() && d.message.empty() &&
+          d.hardware_id.empty() && d.name == "vehicle_cmd_gate: emergency_stop_operation") {
           return true;
         }
         if (
-          d.level == DiagnosticStatus::ERROR && 
-          d.values.empty() &&
-          d.message.empty() &&
+          d.level == DiagnosticStatus::ERROR && d.values.empty() && d.message.empty() &&
           d.hardware_id.empty()) {
-          return  d.name == "/autoware/modes/autonomous" ||
-                  d.name == "/planning/autonomous_available" ||
-                  d.name == "/planning/in_lane_moderate_stop" ||
-                  d.name == "/planning/emergency_stop" ||
-                  d.name == "/system/002-emergency_stop_operation/vehicle_cmd_gate" ||
-                  d.name == "/planning/000-component_status/route_state";
+          return d.name == "/autoware/modes/autonomous" ||
+                 d.name == "/planning/autonomous_available" ||
+                 d.name == "/planning/in_lane_moderate_stop" ||
+                 d.name == "/planning/emergency_stop" ||
+                 d.name == "/system/002-emergency_stop_operation/vehicle_cmd_gate" ||
+                 d.name == "/planning/000-component_status/route_state";
         }
         if (
-          d.name == "/adapi/node/routing: state" && 
-          d.values.empty() &&
-          d.message == "2" &&
+          d.name == "/adapi/node/routing: state" && d.values.empty() && d.message == "2" &&
           d.hardware_id == "none") {
           return true;
         }
-        
+
         return false;
       };
       for (auto & d : spf) {

--- a/awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp
+++ b/awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp
@@ -167,20 +167,28 @@ void AutowareIvAutowareStatePublisher::getHazardStatusInfo(
     auto spf =
       diagnostics_filter::extractLeafDiagnostics(status->hazard_status.status.diagnostics_spf);
 
-    const bool wfr = (status->autoware_state == AutowareState::WAITING_FOR_ROUTE);
-    const bool pln = (status->autoware_state == AutowareState::PLANNING);
+    const bool waiting_for_route =
+      (status->autoware_state == AutowareState::WAITING_FOR_ROUTE);
+    const bool planning = (status->autoware_state == AutowareState::PLANNING);
     // it's not changed status->arrived_goal if set force goal.
-    if (wfr || pln) {
-      const auto should_downgrade = [wfr, pln](const DiagnosticStatus & d) -> bool {
+    if (waiting_for_route || planning) {
+      const auto should_downgrade = [waiting_for_route, planning](
+                                      const DiagnosticStatus & d) -> bool {
         const bool routing_unset =
           d.name == "/adapi/node/routing: state" && d.values.empty() &&
-          d.message == "2" && d.hardware_id == "none";  // tier4_planning_msgs/RouteState UNSET
-        if (pln) {
+          d.message == "2" && d.hardware_id == "none";  // autoware_planning_msgs/RouteState::UNSET
+
+        if (planning) {
+          const bool empty_error = d.level == DiagnosticStatus::ERROR && d.values.empty() &&
+                                   d.message.empty() && d.hardware_id.empty();
           return routing_unset ||
-                 (d.level == DiagnosticStatus::ERROR && d.values.empty() && d.message.empty() &&
-                  d.hardware_id.empty() &&
-                  d.name == "/planning/000-component_status/route_state");
+                 (empty_error && d.name == "/planning/000-component_status/route_state");
         }
+
+        if (!waiting_for_route) {
+          return false;
+        }
+
         if (
           d.level == DiagnosticStatus::STALE && d.values.empty() && d.message.empty() &&
           d.hardware_id.empty() && d.name == "vehicle_cmd_gate: emergency_stop_operation") {


### PR DESCRIPTION
## Description
When the vehicle reaches the destination, the route goes to unset and shows as an error on the FMS. A lasting fix is to be worked out later; in the meantime, the diagnostics_spf payload sent to the FMS is overwritten. Only diags that would be errors at goal are changed OK, so you still know which diags are occurring.

JIRA: [Link](https://tier4.atlassian.net/browse/T4DEV-52248?focusedCommentId=305926&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-305926)

## Changes
`awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp`
- In getHazardStatusInfo, apply state-dependent filtering on SPF diagnostics after extractLeafDiagnostics.
- PLANNING
  - Relax /adapi/node/routing: state when it matches RouteState UNSET-like conditions (e.g. message == "2").
  - Relax empty-field ERROR on /planning/000-component_status/route_state.
- WAITING_FOR_ROUTE
  - Relax STALE vehicle_cmd_gate: emergency_stop_operation (with empty-value constraints).
  - Relax empty-field ERROR on: /autoware/modes/autonomous, /planning/autonomous_available, /planning/in_lane_moderate_stop, /planning/emergency_stop, /system/002-emergency_stop_operation/vehicle_cmd_gate, /planning/000-component_status/route_state.
  - Also applies the same routing unset style rule as above where applicable.
- Include diagnostic_msgs/msg/diagnostic_status.hpp for DiagnosticStatus::OK / ERROR / STALE.
- `.pre-commit-config.yaml`
  - Bump https://github.com/tier4/pre-commit-hooks-ros from v0.8.0 to v0.10.2 for pre-commit consistency.

## How was this PR tested?
I integrated with the FMS using the following Pilot-Auto versions and conducted tests in Psim:
- pilot-auto v0.64.1
- pilot-auto.x1 v2026.03
- pilot-auto.xx1 beta/v0.52
- pilot-auto.x2 beta/v4.4

I also ran tests for both normal goal arrival and forced goal conditions.
## Notes for reviewers

None.

## Effects on system behavior

None.
