### PR TITLE
fix(awapi): downgrade route-unset SPF diagnostics in Planning for FMS）

### DIFF
--- a/awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp
+++ b/awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp
@@ -166,10 +166,21 @@ void AutowareIvAutowareStatePublisher::getHazardStatusInfo(
 
     auto spf =
       diagnostics_filter::extractLeafDiagnostics(status->hazard_status.status.diagnostics_spf);
-    if (
-      // it's not changed status->arrived_goal if set force goal.
-      status->autoware_state == AutowareState::WAITING_FOR_ROUTE) {
-      const auto should_downgrade_error_to_ok = [](const DiagnosticStatus & d) -> bool {
+
+    const bool wfr = (status->autoware_state == AutowareState::WAITING_FOR_ROUTE);
+    const bool pln = (status->autoware_state == AutowareState::PLANNING);
+    // it's not changed status->arrived_goal if set force goal.
+    if (wfr || pln) {
+      const auto should_downgrade = [wfr, pln](const DiagnosticStatus & d) -> bool {
+        const bool routing_unset =
+          d.name == "/adapi/node/routing: state" && d.values.empty() &&
+          d.message == "2" && d.hardware_id == "none";  // tier4_planning_msgs/RouteState UNSET
+        if (pln) {
+          return routing_unset ||
+                 (d.level == DiagnosticStatus::ERROR && d.values.empty() && d.message.empty() &&
+                  d.hardware_id.empty() &&
+                  d.name == "/planning/000-component_status/route_state");
+        }
         if (
           d.level == DiagnosticStatus::STALE && d.values.empty() && d.message.empty() &&
           d.hardware_id.empty() && d.name == "vehicle_cmd_gate: emergency_stop_operation") {
@@ -185,20 +196,15 @@ void AutowareIvAutowareStatePublisher::getHazardStatusInfo(
                  d.name == "/system/002-emergency_stop_operation/vehicle_cmd_gate" ||
                  d.name == "/planning/000-component_status/route_state";
         }
-        if (
-          d.name == "/adapi/node/routing: state" && d.values.empty() && d.message == "2" &&
-          d.hardware_id == "none") {
-          return true;
-        }
-
-        return false;
+        return routing_unset;
       };
       for (auto & d : spf) {
-        if (should_downgrade_error_to_ok(d)) {
+        if (should_downgrade(d)) {
           d.level = DiagnosticStatus::OK;
         }
       }
     }
+
     status->hazard_status.status.diagnostics_spf = std::move(spf);
   }
   status->hazard_status.status.diagnostics_lf =

--- a/awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp
+++ b/awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp
@@ -167,16 +167,15 @@ void AutowareIvAutowareStatePublisher::getHazardStatusInfo(
     auto spf =
       diagnostics_filter::extractLeafDiagnostics(status->hazard_status.status.diagnostics_spf);
 
-    const bool waiting_for_route =
-      (status->autoware_state == AutowareState::WAITING_FOR_ROUTE);
+    const bool waiting_for_route = (status->autoware_state == AutowareState::WAITING_FOR_ROUTE);
     const bool planning = (status->autoware_state == AutowareState::PLANNING);
     // it's not changed status->arrived_goal if set force goal.
     if (waiting_for_route || planning) {
-      const auto should_downgrade = [waiting_for_route, planning](
-                                      const DiagnosticStatus & d) -> bool {
+      const auto should_downgrade = [waiting_for_route,
+                                     planning](const DiagnosticStatus & d) -> bool {
         const bool routing_unset =
-          d.name == "/adapi/node/routing: state" && d.values.empty() &&
-          d.message == "2" && d.hardware_id == "none";  // autoware_planning_msgs/RouteState::UNSET
+          d.name == "/adapi/node/routing: state" && d.values.empty() && d.message == "2" &&
+          d.hardware_id == "none";  // autoware_planning_msgs/RouteState::UNSET
 
         if (planning) {
           const bool empty_error = d.level == DiagnosticStatus::ERROR && d.values.empty() &&

--- a/awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp
+++ b/awapi_awiv_adapter/src/awapi_autoware_state_publisher.cpp
@@ -167,20 +167,28 @@ void AutowareIvAutowareStatePublisher::getHazardStatusInfo(
     auto spf =
       diagnostics_filter::extractLeafDiagnostics(status->hazard_status.status.diagnostics_spf);
 
-    const bool wfr = (status->autoware_state == AutowareState::WAITING_FOR_ROUTE);
-    const bool pln = (status->autoware_state == AutowareState::PLANNING);
+    const bool waiting_for_route =
+      (status->autoware_state == AutowareState::WAITING_FOR_ROUTE);
+    const bool planning = (status->autoware_state == AutowareState::PLANNING);
     // it's not changed status->arrived_goal if set force goal.
-    if (wfr || pln) {
-      const auto should_downgrade = [wfr, pln](const DiagnosticStatus & d) -> bool {
+    if (waiting_for_route || planning) {
+      const auto should_downgrade = [waiting_for_route, planning](
+                                      const DiagnosticStatus & d) -> bool {
         const bool routing_unset =
           d.name == "/adapi/node/routing: state" && d.values.empty() &&
-          d.message == "2" && d.hardware_id == "none";  // tier4_planning_msgs/RouteState UNSET
-        if (pln) {
+          d.message == "2" && d.hardware_id == "none";  // autoware_planning_msgs/RouteState::UNSET
+
+        if (planning) {
+          const bool empty_error = d.level == DiagnosticStatus::ERROR && d.values.empty() &&
+                                   d.message.empty() && d.hardware_id.empty();
           return routing_unset ||
-                 (d.level == DiagnosticStatus::ERROR && d.values.empty() && d.message.empty() &&
-                  d.hardware_id.empty() &&
-                  d.name == "/planning/000-component_status/route_state");
+                 (empty_error && d.name == "/planning/000-component_status/route_state");
         }
+
+        if (!waiting_for_route) {
+          return false;
+        }
+
         if (
           d.level == DiagnosticStatus::STALE && d.values.empty() && d.message.empty() &&
           d.hardware_id.empty() && d.name == "vehicle_cmd_gate: emergency_stop_operation") {


### PR DESCRIPTION
## Description

### Summary

Extends the existing `diagnostics_spf` filtering in `getHazardStatusInfo` so that, when **Autoware state is `Planning`**, selected hazard SPF diagnostics that reflect a **transient unset route** are downgraded to `OK` before publishing on Awapi. This reduces **false-positive error reporting on the FMS** when the vehicle is in Planning while the AD API routing state is still **UNSET** (`message` `"2"`), without changing Autoware’s internal hazard logic.

### Motivation

After goal or during re-route, the FMS can show errors for **`/adapi/node/routing: state`** and **`/planning/000-component_status/route_state`** even when the system is legitimately in **Planning** with route **UNSET**. Downgrades were previously only applied in **`WaitingForRoute`**; **Planning** was excluded, so the same benign combinations could still surface as FMS anomalies.

### Behavior change

- **`Planning`**: Downgrade SPF diagnostics only if:
  - **`/adapi/node/routing: state`**: empty `values`, `hardware_id` is `"none"`, and `message` is `"2"` (same encoding as `autoware_planning_msgs/RouteState::UNSET`), **or**
  - **`/planning/000-component_status/route_state`**: `ERROR` with empty `values`, `message`, and `hardware_id`.
- **`WaitingForRoute`**: Unchanged; existing broader SPF downgrade list still applies only in that state.



## How was this PR tested?

- [x] Enter **Planning** with routing diagnostic **`message: "2"`** and confirm **`hazard_status.status.diagnostics_spf`** shows **`OK`** on Awapi output while FMS no longer flags it as an error (if FMS consumes Awapi SPF) with the real vehicle on April 27.
- [x] Confirm **real** Planning faults (e.g. other SPF names, non-empty diagnostic fields) are **not** downgraded with the real vehicle on April 27..



## Notes for reviewers


- This only adjusts **`diagnostics_spf`** on **`AwapiAutowareStatus`**; it does not alter upstream hazard computation or other diagnostic channels.
- **`message == "2"`** is the wire representation observed from **`/adapi/node/routing: state`**; it matches **`RouteState::UNSET`** in `tier4_planning_msgs`.


## Effects on system behavior

None.
