### PR TITLE
chore(ci): update GitHub Actions runner to ubuntu-24.04

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   backport:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     # Only react to merged PRs for security reasons.
     # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
     if: >

--- a/.github/workflows/pre-commit-optional.yaml
+++ b/.github/workflows/pre-commit-optional.yaml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   pre-commit-optional:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   pre-commit:
     if: ${{ github.event.repository.private }} # Use pre-commit.ci for public repositories
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate token
         id: generate-token

--- a/.github/workflows/spell-check-differential.yaml
+++ b/.github/workflows/spell-check-differential.yaml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   spell-check-differential:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/sync-files.yaml
+++ b/.github/workflows/sync-files.yaml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   sync-files:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate token
         id: generate-token


### PR DESCRIPTION
## Summary
- Update GitHub Actions runner from `ubuntu-22.04` to `ubuntu-24.04`
- 5 workflow file(s) updated
- `ubuntu-22.04-m` and other variant runners are unchanged

## Test plan
- [ ] Verify CI workflows run successfully on `ubuntu-24.04`
